### PR TITLE
Specify ssl_version in EasyPost.http_config

### DIFF
--- a/lib/easypost.rb
+++ b/lib/easypost.rb
@@ -66,7 +66,8 @@ module EasyPost
     @@http_config ||= {
       timeout: 60,
       open_timeout: 30,
-      verify_ssl: false
+      verify_ssl: false,
+      ssl_version: "TLSv1",
     }
   end
 


### PR DESCRIPTION
Might be defaulting to SSLv2/3 which is non-POODLE safe.
