### PR TITLE
Bundlerize

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,2 @@
+require "bundler/gem_tasks"
+

--- a/easypost.gemspec
+++ b/easypost.gemspec
@@ -13,12 +13,14 @@ Gem::Specification.new do |spec|
   spec.email       = 'contact@easypost.com'
   spec.homepage    = 'https://www.easypost.com/docs'
 
-  spec.files         = `git ls-files`.split("\n")
-  spec.test_files    = `git ls-files -- test/*`.split("\n")
-  spec.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
-  spec.require_path  = 'lib'
+  spec.files         = `git ls-files -z`.split("\x0")
+  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
+  spec.require_paths = ['lib']
 
-  spec.add_dependency('rest-client', '~> 1.4')
-  spec.add_dependency('multi_json', '>= 1.0.4', '< 2')
-  spec.add_development_dependency('rspec', "~> 2.13.0")
+  spec.add_dependency 'rest-client', '~> 1.4'
+  spec.add_dependency 'multi_json', '>= 1.0.4', '< 2'
+  spec.add_development_dependency 'bundler', '~> 1.7'
+  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rspec', '~> 2.13.0'
 end


### PR DESCRIPTION
Merge from `bundle gem` templates

Background:
As a gem user, when a gem is updated, I'd like to check the diffs on GitHub like https://github.com/rails/rails/compare/v4.1.6...v4.1.7 
To do so, git tag is useful. Bundler's `rake release` task makes us easy to create git tag.
In addition, it would be helpful if you set `Source Code URL` with `https://github.com/EasyPost/easypost-ruby` on https://rubygems.org/gems/easypost
