### PR TITLE
Fix issue with undefined method `fetch' for #<String:0x007faa8819aca0>

### DIFF
--- a/lib/easypost/error.rb
+++ b/lib/easypost/error.rb
@@ -14,9 +14,11 @@ module EasyPost
       @http_body = http_body
       @json_body = json_body
 
-      @param = @json_body.fetch(:error, {}).fetch(:param, nil)
-      @code = @json_body.fetch(:error, {}).fetch(:code, nil)
-      @errors = @json_body.fetch(:error, {}).fetch(:errors, nil)
+      if (error = @json_body.fetch(:error, {})).is_a?(Hash)
+        @param  = error.fetch(:param, nil)
+        @code   = error.fetch(:code, nil)
+        @errors = error.fetch(:errors, nil)
+      end
 
       super(message)
     end

--- a/spec/shipment_spec.rb
+++ b/spec/shipment_spec.rb
@@ -16,34 +16,52 @@ describe EasyPost::Shipment do
   end
 
   describe '#buy' do
-    it 'purchases postage for an international shipment' do
+    context 'with valid attributes' do
+      it 'purchases postage for an international shipment' do
 
-      shipment = EasyPost::Shipment.create(
-        to_address: EasyPost::Address.create(ADDRESS[:canada]),
-        from_address: ADDRESS[:california],
-        parcel: EasyPost::Parcel.create(PARCEL[:dimensions]),
-        customs_info: EasyPost::CustomsInfo.create(CUSTOMS_INFO[:shirt])
-      )
-      expect(shipment).to be_an_instance_of(EasyPost::Shipment)
+        shipment = EasyPost::Shipment.create(
+          to_address: EasyPost::Address.create(ADDRESS[:canada]),
+          from_address: ADDRESS[:california],
+          parcel: EasyPost::Parcel.create(PARCEL[:dimensions]),
+          customs_info: EasyPost::CustomsInfo.create(CUSTOMS_INFO[:shirt])
+        )
+        expect(shipment).to be_an_instance_of(EasyPost::Shipment)
 
-      shipment.buy(
-        rate: shipment.lowest_rate("usps")
-      )
-      expect(shipment.postage_label.label_url.length).to be > 0
+        shipment.buy(
+          rate: shipment.lowest_rate("usps")
+        )
+        expect(shipment.postage_label.label_url.length).to be > 0
+      end
+
+      it 'purchases postage for a domestic shipment' do
+        shipment = EasyPost::Shipment.create(
+          to_address: EasyPost::Address.create(ADDRESS[:missouri]),
+          from_address: ADDRESS[:california],
+          parcel: EasyPost::Parcel.create(PARCEL[:dimensions])
+        )
+        expect(shipment).to be_an_instance_of(EasyPost::Shipment)
+
+        shipment.buy(
+          rate: shipment.lowest_rate("usps")
+        )
+        expect(shipment.postage_label.label_url.length).to be > 0
+      end
     end
 
-    it 'purchases postage for a domestic shipment' do
-      shipment = EasyPost::Shipment.create(
-        to_address: EasyPost::Address.create(ADDRESS[:missouri]),
-        from_address: ADDRESS[:california],
-        parcel: EasyPost::Parcel.create(PARCEL[:dimensions])
-      )
-      expect(shipment).to be_an_instance_of(EasyPost::Shipment)
+    context 'with invalid from address' do
+      let(:invalid_from_address) { ADDRESS[:california].clone.tap { |addr| addr[:phone] = '33' } }
 
-      shipment.buy(
-        rate: shipment.lowest_rate("usps")
-      )
-      expect(shipment.postage_label.label_url.length).to be > 0
+      it 'throws error', k: true do
+        shipment = EasyPost::Shipment.create(
+            to_address: EasyPost::Address.create(ADDRESS[:canada]),
+            from_address: invalid_from_address,
+            parcel: EasyPost::Parcel.create(PARCEL[:dimensions]),
+            customs_info: EasyPost::CustomsInfo.create(CUSTOMS_INFO[:shirt])
+        )
+
+        expect { shipment.buy(rate: shipment.lowest_rate("usps")) }.
+            to raise_error(EasyPost::Error)
+      end
     end
   end
 


### PR DESCRIPTION
### Handle error message when server returns string message instead of Hash - 
`{:error=>"Missing or invalid element: FromPhone. Error encountered (Log ID: 29535)"}`

1. This PR added test coverage for invalid `fromPhone` related error
2. Added required changes to handle the string error message.