### PR TITLE
Fixed Address.create_and_verify to properly raise_verification_failure

### DIFF
--- a/lib/easypost/address.rb
+++ b/lib/easypost/address.rb
@@ -2,6 +2,10 @@ module EasyPost
   class Address < Resource
     attr_accessor :message # Backwards compatibility
 
+    def self.raise_verification_failure
+      raise Error.new("Unable to verify address.")
+    end
+
     def self.create_and_verify(params={}, carrier=nil, api_key=nil)
       wrapped_params = {}
       wrapped_params[self.class_name().to_sym] = params
@@ -23,20 +27,16 @@ module EasyPost
       begin
         response, api_key = EasyPost.request(:get, url + '/verify?carrier=' + String(carrier), @api_key, params)
       rescue
-        raise_verification_failure
+        self.class.raise_verification_failure
       end
 
       if response.has_key?(:address)
         return EasyPost::Util::convert_to_easypost_object(response[:address], api_key)
       else
-        raise_verification_failure
+        self.class.raise_verification_failure
       end
 
       return self
-    end
-
-    def raise_verification_failure
-      raise Error.new("Unable to verify address.")
     end
   end
 end

--- a/lib/easypost/address.rb
+++ b/lib/easypost/address.rb
@@ -2,10 +2,6 @@ module EasyPost
   class Address < Resource
     attr_accessor :message # Backwards compatibility
 
-    def self.raise_verification_failure
-      raise Error.new("Unable to verify address.")
-    end
-
     def self.create_and_verify(params={}, carrier=nil, api_key=nil)
       wrapped_params = {}
       wrapped_params[self.class_name().to_sym] = params
@@ -19,7 +15,7 @@ module EasyPost
         verified_address = EasyPost::Util::convert_to_easypost_object(response[:address], api_key)
         return verified_address
       else
-        raise_verification_failure
+        raise Error.new("Unable to verify address.")
       end
     end
 
@@ -27,13 +23,13 @@ module EasyPost
       begin
         response, api_key = EasyPost.request(:get, url + '/verify?carrier=' + String(carrier), @api_key, params)
       rescue
-        self.class.raise_verification_failure
+        raise Error.new("Unable to verify address.")
       end
 
       if response.has_key?(:address)
         return EasyPost::Util::convert_to_easypost_object(response[:address], api_key)
       else
-        self.class.raise_verification_failure
+        raise Error.new("Unable to verify address.")
       end
 
       return self

--- a/spec/address_spec.rb
+++ b/spec/address_spec.rb
@@ -1,6 +1,17 @@
 require 'spec_helper'
 
 describe EasyPost::Address do
+  describe ".create_and_verify" do
+    context "for a successful response without an address" do
+      it "should raise an error" do
+        expect(EasyPost).to receive(:request).and_return([{}, ""])
+        expect {
+          EasyPost::Address.create_and_verify(ADDRESS[:california])
+        }.to raise_error EasyPost::Error, /Unable to verify addres/
+      end
+    end
+  end
+
   describe '#create' do
     it 'creates an address object' do
       address = EasyPost::Address.create(ADDRESS[:california])


### PR DESCRIPTION
EasyPost::Address.create_and_verify could not invoke
raise_verification_failure instance method, so it’s
now a class method.

At line https://github.com/EasyPost/easypost-ruby/compare/master...dimroc:master#diff-005a9ba9d83f4a1247ea9d044f86c63bL26 you can see that the class method is trying to invoke
`raise_verification_failure` which is an instance method.