### PR TITLE
Address fields validation added

### DIFF
--- a/lib/easypost/address.rb
+++ b/lib/easypost/address.rb
@@ -3,6 +3,13 @@ module EasyPost
     attr_accessor :message # Backwards compatibility
 
     def self.create_and_verify(params={}, carrier=nil, api_key=nil)
+      Address.validate_params(
+        params[:street1],
+        params[:city],
+        params[:state],
+        params[:zip],
+        params[:country],
+      )
       wrapped_params = {}
       wrapped_params[self.class_name().to_sym] = params
       wrapped_params[:carrier] = carrier
@@ -20,6 +27,14 @@ module EasyPost
     end
 
     def verify(params={}, carrier=nil)
+      Address.validate_params(
+        self.street1,
+        self.city,
+        self.state,
+        self.zip,
+        self.country
+      )
+
       begin
         response, api_key = EasyPost.request(:get, url + '/verify?carrier=' + String(carrier), @api_key, params)
       rescue
@@ -33,6 +48,20 @@ module EasyPost
       end
 
       return self
+    end
+
+    def self.validate_params(street1=nil, city=nil, state=nil, zip=nil, country=nil)
+      errors = {}
+      errors[:street1] = "can't be empty" unless street1
+      errors[:city] = "can't be empty" unless zip
+      errors[:state] = "can't be empty" unless zip
+      errors[:zip] = "can't be empty" unless city && state
+      errors[:country] = "can't be empty" unless country
+
+      if errors.any?
+        json_body = { error: { errors: errors } }
+        raise Error.new("Unable to verify address.", nil, nil, json_body)
+      end
     end
   end
 end

--- a/spec/address_spec.rb
+++ b/spec/address_spec.rb
@@ -6,7 +6,7 @@ describe EasyPost::Address do
       it "should raise an error" do
         expect(EasyPost).to receive(:request).and_return([{}, ""])
         expect {
-          EasyPost::Address.create_and_verify(ADDRESS[:california])
+          EasyPost::Address.create_and_verify(ADDRESS[:canada_no_phone])
         }.to raise_error EasyPost::Error, /Unable to verify addres/
       end
     end
@@ -76,6 +76,46 @@ describe EasyPost::Address do
       expect {
         address.verify()
       }.to raise_error(EasyPost::Error, /Unable to verify addres/)
+    end
+
+    it 'requires street1 field' do
+      address = EasyPost::Address.create(
+        ADDRESS[:california].reject {|k,v| k == :street1 }
+      )
+
+      begin
+        address.verify()
+      rescue => e
+        expect(e.message).to match /Unable to verify addres/
+        expect(e.errors[:street1]).to match /can't be empty/
+      end
+    end
+
+    it 'requires city and state when zip is empty' do
+      address = EasyPost::Address.create(
+        ADDRESS[:california].reject {|k,v| [:city, :state, :zip].include? k  }
+      )
+
+      begin
+        address.verify()
+      rescue => e
+        expect(e.message).to match /Unable to verify addres/
+        expect(e.errors[:city]).to match /can't be empty/
+        expect(e.errors[:state]).to match /can't be empty/
+      end
+    end
+
+    it 'requires country field' do
+      address = EasyPost::Address.create(
+        ADDRESS[:california].reject {|k,v| k == :country }
+      )
+
+      begin
+        address.verify()
+      rescue => e
+        expect(e.message).to match /Unable to verify addres/
+        expect(e.errors[:country]).to match /can't be empty/
+      end
     end
   end
 end


### PR DESCRIPTION
Address validation requires certain fields to be present. When
validation fails an Error is raised with a hash listing the errors
encountered.

As bonus point, if a required field is missing we avoid to send the
request to EasyPost server, showing the validation errors faster to the
users.

Issue #37