### PR TITLE
change order of api_keys on user test

### DIFF
--- a/spec/user_spec.rb
+++ b/spec/user_spec.rb
@@ -64,8 +64,8 @@ describe EasyPost::User do
   #     api_keys = EasyPost::User.all_api_keys
 
   #     my_keys = api_keys.keys
-  #     expect(my_keys.first.mode).to eq("production")
-  #     expect(my_keys.last.mode).to eq("test")
+  #     expect(my_keys.first.mode).to eq("test")
+  #     expect(my_keys.last.mode).to eq("production")
 
   #     me = EasyPost::User.retrieve_me
   #     children_count = me.children.count


### PR DESCRIPTION
noticed that the order of the keys on this test were incorrect. The test api key is always created first.