### PR TITLE
Rescue if json_body fetch fails

### DIFF
--- a/lib/easypost/error.rb
+++ b/lib/easypost/error.rb
@@ -14,9 +14,9 @@ module EasyPost
       @http_body = http_body
       @json_body = json_body
 
-      @param = @json_body.fetch(:error, {}).fetch(:param, nil)
-      @code = @json_body.fetch(:error, {}).fetch(:code, nil)
-      @errors = @json_body.fetch(:error, {}).fetch(:errors, nil)
+      @param = @json_body.fetch(:error, {}).fetch(:param, nil) rescue nil
+      @code = @json_body.fetch(:error, {}).fetch(:code, nil) rescue nil
+      @errors = @json_body.fetch(:error, {}).fetch(:errors, nil) rescue nil
 
       super(message)
     end


### PR DESCRIPTION
This PR provides a quick fix issue #56. If the nested `fetch` calls fail, then the instances vars will be set to nil, which is the same value as if the keys were missing.