### PR TITLE
rescue argument error when converting response to easypost object

### DIFF
--- a/lib/easypost/util.rb
+++ b/lib/easypost/util.rb
@@ -79,16 +79,22 @@ module EasyPost
       when Array
         return response.map { |i| convert_to_easypost_object(i, api_key, parent) }
       when Hash
-        begin
-          if cls_name = response[:object]
-            cls = types[cls_name]
-          elsif response[:id] && cls_prefix = response[:id][0..response[:id].index('_')]
-            cls = prefixes[cls_prefix[0..-2]]
-          elsif response['id'] && cls_prefix = response['id'][0..response['id'].index('_')]
+        if cls_name = response[:object]
+          cls = types[cls_name]
+        elsif response[:id]
+          if response[:id].index('_').nil?
+            cls = EasyPostObject
+          elsif cls_prefix = response[:id][0..response[:id].index('_')]
             cls = prefixes[cls_prefix[0..-2]]
           end
-        rescue ArgumentError => e
-        end  
+        elsif response['id']
+          if response[:id].index('_').nil?
+            cls = EasyPostObject
+          elsif cls_prefix = response['id'][0..response['id'].index('_')]
+            cls = prefixes[cls_prefix[0..-2]]
+          end
+        end
+
         cls ||= EasyPostObject
         return cls.construct_from(response, api_key, parent, name)
       else

--- a/lib/easypost/util.rb
+++ b/lib/easypost/util.rb
@@ -79,14 +79,16 @@ module EasyPost
       when Array
         return response.map { |i| convert_to_easypost_object(i, api_key, parent) }
       when Hash
-        if cls_name = response[:object]
-          cls = types[cls_name]
-        elsif response[:id] && cls_prefix = response[:id][0..response[:id].index('_')]
-          cls = prefixes[cls_prefix[0..-2]]
-        elsif response['id'] && cls_prefix = response['id'][0..response['id'].index('_')]
-          cls = prefixes[cls_prefix[0..-2]]
-        end
-
+        begin
+          if cls_name = response[:object]
+            cls = types[cls_name]
+          elsif response[:id] && cls_prefix = response[:id][0..response[:id].index('_')]
+            cls = prefixes[cls_prefix[0..-2]]
+          elsif response['id'] && cls_prefix = response['id'][0..response['id'].index('_')]
+            cls = prefixes[cls_prefix[0..-2]]
+          end
+        rescue ArgumentError => e
+        end  
         cls ||= EasyPostObject
         return cls.construct_from(response, api_key, parent, name)
       else

--- a/spec/shipment_spec.rb
+++ b/spec/shipment_spec.rb
@@ -13,6 +13,19 @@ describe EasyPost::Shipment do
       expect(shipment.from_address).to be_an_instance_of(EasyPost::Address)
 
     end
+
+    it 'creates a shipment object when options hash contains id' do
+
+      shipment = EasyPost::Shipment.create(
+        to_address: ADDRESS[:california],
+        from_address: EasyPost::Address.create(ADDRESS[:missouri]),
+        parcel: EasyPost::Parcel.create(PARCEL[:dimensions]),
+        options: OPTIONS[:mws]
+      )
+      expect(shipment).to be_an_instance_of(EasyPost::Shipment)
+      expect(shipment.options.fulfiller_order_items.first).to be_an_instance_of(EasyPost::EasyPostObject)
+
+    end
   end
 
   describe '#buy' do

--- a/spec/support/constant.rb
+++ b/spec/support/constant.rb
@@ -95,3 +95,12 @@ CUSTOMS_INFO = {
     restriction_comments: ''
   }
 }
+
+OPTIONS = {
+  mws: {
+    fulfiller_order_items: [{
+      id: '12345678901234',
+      quantity: 1
+    }]
+  }
+}


### PR DESCRIPTION
When using Amazon MWS new options are required.

fulfiller_order_id: "1234567890",
    fulfiller_order_items: [
      {
        id: "1234567890",
        quantity: "1",
      }
    ]

On shipment create, it was trying to convert fulfiller_order_items to an easypost object because it has an 'id' key inside it. This would throw an argument error.

easypost-2.7.1/lib/easypost/util.rb:84:in `convert_to_easypost_object': bad value for range (ArgumentError)

This is a patch to rescue for that error since it shouldn't be trying to convert this option to an easypost object in the first place.