### PR TITLE
Prevent lowest_rate from modifying carriers and services parameters

### DIFF
--- a/lib/easypost/shipment.rb
+++ b/lib/easypost/shipment.rb
@@ -66,7 +66,7 @@ module EasyPost
 
       self.get_rates unless self.rates
 
-      carriers = carriers.is_a?(String) ? carriers.split(',') : Array(carriers)
+      carriers = carriers.is_a?(String) ? carriers.split(',') : Array(carriers).clone
       carriers.map!(&:downcase)
       carriers.map!(&:strip)
 
@@ -79,7 +79,7 @@ module EasyPost
         end
       end
 
-      services = services.is_a?(String) ? services.split(',') : Array(services)
+      services = services.is_a?(String) ? services.split(',') : Array(services).clone
       services.map!(&:downcase)
       services.map!(&:strip)
 

--- a/spec/shipment_spec.rb
+++ b/spec/shipment_spec.rb
@@ -130,6 +130,18 @@ describe EasyPost::Shipment do
 
         expect(rate.service).to eql('ParcelSelect')
       end
+
+      it 'doesn\'t modify carriers array' do
+        carriers = %w(USPS)
+        @shipment.lowest_rate(carriers)
+        expect(carriers).to eq(%w(USPS))
+      end
+
+      it 'doesn\'t modify services array' do
+        services = %w(ParcelSelect)
+        @shipment.lowest_rate('USPS', services)
+        expect(services).to eq(%w(ParcelSelect))
+      end
     end
   end
 


### PR DESCRIPTION
Now if you pass carriers or services as array to lowest_rate method, it modifies it internally with map! and strip! This is very unpredictable behavior. I propose to clone carriers and services parameters if it was passed as an array.