### PR TITLE
enable certificate verification by default

### DIFF
--- a/lib/easypost.rb
+++ b/lib/easypost.rb
@@ -74,7 +74,7 @@ module EasyPost
     @@http_config ||= {
       timeout: 60,
       open_timeout: 30,
-      verify_ssl: false,
+      verify_ssl: OpenSSL::SSL::VERIFY_PEER,
       ssl_version: :TLSv1_2,
     }
   end


### PR DESCRIPTION
This enables validation of our TLS/SSL certificate by default.

This verification has been disabled since the first commit to this repo with no explanation. I imagine someone was using an intercepting proxy to test things and didn't want to set up a trust store for its root CA.

I tested that without this change I can freely intercept sessions using `mitmproxy` and that with this change I cannot.

Fixes #72.