### PR TITLE
Adding Shipment Invoice & Refund Report to Prefix & Type Lists

### DIFF
--- a/lib/easypost/util.rb
+++ b/lib/easypost/util.rb
@@ -42,6 +42,8 @@ module EasyPost
         'ShipmentReport' => Report,
         'PaymentLogReport' => Report,
         'TrackerReport' => Report,
+        'RefundReport' => Report,
+        'ShipmentInvoiceReport' => Report,
         'Webhook' => Webhook
       }
 
@@ -70,6 +72,8 @@ module EasyPost
         'shprep' => Report,
         'plrep' => Report,
         'trkrep' => Report,
+        'refrep' => Report,
+        'shpinvrep' => Report,
         'hook' => Webhook
       }
 


### PR DESCRIPTION
The refund and the new shipment invoice report were missing from the prefix and type list. I've added them here.