### PR TITLE
Use CGI rather than URI to avoid ruby 2.7.1 warnings

### DIFF
--- a/lib/easypost/util.rb
+++ b/lib/easypost/util.rb
@@ -117,7 +117,7 @@ module EasyPost
     end
 
     def self.url_encode(key)
-      URI.escape(key.to_s, Regexp.new("[^#{URI::PATTERN::UNRESERVED}]"))
+      CGI.escape(key.to_s)
     end
 
     def self.flatten_params(params, parent_key=nil)


### PR DESCRIPTION
note: test suite is not currently green, but tests around this useage seem ok