### PR TITLE
convert url_encode function to use encode_www_form_component instead of URI.escape, since it is actually being used to encode values in a query string; add spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![Build Status](https://travis-ci.org/EasyPost/easypost-ruby.svg?branch=master)](https://travis-ci.org/EasyPost/easypost-ruby)
 
-
 EasyPost is a simple shipping API. You can sign up for an account at https://easypost.com
 
 Installation

--- a/lib/easypost/util.rb
+++ b/lib/easypost/util.rb
@@ -117,7 +117,7 @@ module EasyPost
     end
 
     def self.url_encode(key)
-      URI.escape(key.to_s, Regexp.new("[^#{URI::PATTERN::UNRESERVED}]"))
+      URI.encode_www_form_component(key.to_s)
     end
 
     def self.flatten_params(params, parent_key=nil)

--- a/spec/util_spec.rb
+++ b/spec/util_spec.rb
@@ -16,7 +16,7 @@ describe EasyPost::Util do
     it "flattens" do
       expect(described_class.flatten_params({:foo => "bar"})).to eq([["foo", "bar"]])
       expect(described_class.flatten_params({:foo => ["bar", "baz"]})).to eq([["foo[0]", "bar"], ["foo[1]", "baz"]])
-      expect(described_class.flatten_params({:foo => {"bar": "baz"}})).to eq([["foo[bar]", "baz"]])
+      expect(described_class.flatten_params({:foo => {"bar" => "baz"}})).to eq([["foo[bar]", "baz"]])
     end
   end
 end

--- a/spec/util_spec.rb
+++ b/spec/util_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+describe EasyPost::Util do
+  describe '#url_encode' do
+    it 'encodes' do
+      expect(described_class.url_encode('foobar')).to eq('foobar')
+      expect(described_class.url_encode('foo bar')).to eq('foo+bar')
+      expect(described_class.url_encode('foo/bar')).to eq('foo%2Fbar')
+      expect(described_class.url_encode('foo\\bar')).to eq('foo%5Cbar')
+      expect(described_class.url_encode('foo!bar')).to eq('foo%21bar')
+      expect(described_class.url_encode('foo/💩')).to eq('foo%2F%F0%9F%92%A9')
+    end
+  end
+
+  describe "#flatten_params" do
+    it "flattens" do
+      expect(described_class.flatten_params({:foo => "bar"})).to eq([["foo", "bar"]])
+      expect(described_class.flatten_params({:foo => ["bar", "baz"]})).to eq([["foo[0]", "bar"], ["foo[1]", "baz"]])
+      expect(described_class.flatten_params({:foo => {"bar": "baz"}})).to eq([["foo[bar]", "baz"]])
+    end
+  end
+end


### PR DESCRIPTION
This changes spaces from `%20` to `+`, but that shouldn't affect anything. It also encodes the bang character, but that also shouldn't affect anything.