### PR TITLE
Update Dependencies, fix tests, and test against ruby2.6/7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 rvm:
-    - 2.0
-    - 2.1
-    - 2.3
     - 2.5
+    - 2.6
+    - 2.7
 script: "bundle exec rspec"

--- a/easypost.gemspec
+++ b/easypost.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
-  spec.required_ruby_version = "~> 2.0"
+  spec.required_ruby_version = "~> 2.5"
 
   spec.add_dependency "rest-client", "~> 2.1"
   spec.add_dependency 'multi_json', '~> 1.14'

--- a/easypost.gemspec
+++ b/easypost.gemspec
@@ -1,27 +1,28 @@
 # coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
+
+lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'easypost/version'
+require "easypost/version"
 
 Gem::Specification.new do |spec|
-  spec.name        = 'easypost'
-  spec.version     = EasyPost::VERSION
-  spec.date        = Time.now.strftime("%Y-%m-%d")
-  spec.summary     = 'EasyPost Ruby Client Library'
-  spec.description = 'Client library for accessing the EasyPost shipping API via Ruby.'
-  spec.authors     = ['Sawyer Bateman']
-  spec.email       = 'contact@easypost.com'
-  spec.homepage    = 'https://www.easypost.com/docs'
+  spec.name = "easypost"
+  spec.version = EasyPost::VERSION
+  spec.date = Time.now.strftime("%Y-%m-%d")
+  spec.summary = "EasyPost Ruby Client Library"
+  spec.description = "Client library for accessing the EasyPost shipping API via Ruby."
+  spec.authors = ["Jake Epstein", "Andrew Tribone", "James Brown"]
+  spec.email = "support@easypost.com"
+  spec.homepage = "https://www.easypost.com/docs"
 
-  spec.files         = `git ls-files -z`.split("\x0")
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
-  spec.require_paths = ['lib']
-  spec.required_ruby_version = '~> 2.0'
+  spec.files = `git ls-files -z`.split("\x0")
+  spec.executables = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  spec.test_files = spec.files.grep(%r{^(test|spec|features)/})
+  spec.require_paths = ["lib"]
+  spec.required_ruby_version = "~> 2.0"
 
-  spec.add_dependency 'rest-client', '>= 1.7'
-  spec.add_dependency 'multi_json', '>= 1.3.0'
-  spec.add_development_dependency 'bundler', '~> 1.7'
-  spec.add_development_dependency 'rake', '~> 10.0'
-  spec.add_development_dependency 'rspec', '~> 2.13'
+  spec.add_dependency "rest-client", "~> 2.1"
+  spec.add_dependency 'multi_json', '~> 1.14'
+  spec.add_development_dependency "rake", "~> 13.0"
+  spec.add_development_dependency "rspec", "~> 3.9"
+  spec.add_development_dependency "pry", "~> 0.13"
 end

--- a/lib/easypost.rb
+++ b/lib/easypost.rb
@@ -104,7 +104,7 @@ module EasyPost
     end
 
     headers = {
-      :user_agent => "EasyPost/v2 RubyClient/#{VERSION}",
+      :user_agent => "EasyPost/v2 RubyClient/#{VERSION} Ruby/#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}",
       :authorization => "Bearer #{api_key}",
       :content_type => 'application/x-www-form-urlencoded'
     }.merge(headers)

--- a/spec/pickup_spec.rb
+++ b/spec/pickup_spec.rb
@@ -1,10 +1,9 @@
 require 'spec_helper'
 
 describe EasyPost::Pickup do
-  before { EasyPost.api_key = "cueqNZUb3ldeWTNX7MU3Mel8UXtaAMUi" }
-
+  let(:noon_tomorrow) { (Date.today + 1).to_datetime + Rational(12, 24) }
   let(:shipment) do
-    shipment = EasyPost::Shipment.create(
+    EasyPost::Shipment.create(
       to_address: ADDRESS[:california],
       from_address: ADDRESS[:missouri],
       parcel: PARCEL[:dimensions]
@@ -13,14 +12,14 @@ describe EasyPost::Pickup do
 
   describe '#create' do
     it 'creates a pickup and returns rates' do
-      shipment.buy(rate: shipment.lowest_rate("ups", "NextDayAirEarlyAM"))
+      shipment.buy(rate: shipment.lowest_rate("UPS", "NextDayAirEarlyAM"))
       pickup = EasyPost::Pickup.create(
         address: ADDRESS[:missouri],
         reference: "12345678",
-        min_datetime: DateTime.now(),
-        max_datetime: DateTime.now() + 14400,
+        min_datetime: noon_tomorrow,
+        max_datetime: noon_tomorrow,
         is_account_address: false,
-        instructions: "",
+        instructions: "At the front door.",
         shipment: shipment
       )
 
@@ -29,28 +28,30 @@ describe EasyPost::Pickup do
     end
 
     it 'fails to create a pickup' do
-      shipment.buy(rate: shipment.lowest_rate("ups", "NextDayAirEarlyAM"))
-      expect { pickup = EasyPost::Pickup.create(
-        address: ADDRESS[:california],
-        reference: "12345678",
-        max_datetime: DateTime.now() + 14400,
-        is_account_address: false,
-        instructions: "",
-        shipment: shipment
-      ) }.to raise_exception(EasyPost::Error, /Invalid request, 'min_datetime' is required./)
+      shipment.buy(rate: shipment.lowest_rate("UPS", "NextDayAirEarlyAM"))
+      expect {
+        EasyPost::Pickup.create(
+          address: ADDRESS[:california],
+          reference: "12345678",
+          max_datetime: noon_tomorrow,
+          is_account_address: false,
+          instructions: "At the front door.",
+          shipment: shipment
+        )
+      } .to raise_exception(EasyPost::Error, /Invalid request, 'min_datetime' is required./)
     end
   end
 
   describe '#buy' do
     it 'buys a pickup rate' do
-      shipment.buy(rate: shipment.lowest_rate("ups", "NextDayAirEarlyAM"))
+      shipment.buy(rate: shipment.lowest_rate("UPS", "NextDayAirEarlyAM"))
       pickup = EasyPost::Pickup.create(
         address: ADDRESS[:california],
         reference: "buy12345678",
-        min_datetime: DateTime.now(),
-        max_datetime: DateTime.now() + 14400,
+        min_datetime: noon_tomorrow,
+        max_datetime: noon_tomorrow,
         is_account_address: false,
-        instructions: "",
+        instructions: "At the front door.",
         shipment: shipment
       )
       pickup.buy(pickup.pickup_rates.first)
@@ -61,14 +62,14 @@ describe EasyPost::Pickup do
 
   describe '#cancel' do
     it 'cancels a pickup' do
-      shipment.buy(rate: shipment.lowest_rate("ups", "NextDayAirEarlyAM"))
+      shipment.buy(rate: shipment.lowest_rate("UPS", "NextDayAirEarlyAM"))
       pickup = EasyPost::Pickup.create(
         address: ADDRESS[:california],
         reference: "buy12345678",
-        min_datetime: DateTime.now(),
-        max_datetime: DateTime.now() + 14400,
+        min_datetime: noon_tomorrow,
+        max_datetime: noon_tomorrow,
         is_account_address: false,
-        instructions: "",
+        instructions: "At the front door.",
         shipment: shipment
       )
       pickup.buy(pickup.pickup_rates.first)

--- a/spec/shipment_spec.rb
+++ b/spec/shipment_spec.rb
@@ -135,7 +135,7 @@ describe EasyPost::Shipment do
 
   describe '#retrieve' do
     it 'retrieves shipment by tracking_code and correctly sets ID field (this was a bug in python)' do
-      tracking_code = "LN123456789US"
+      tracking_code = "CM218228743US"
       shipment = EasyPost::Shipment.retrieve(tracking_code)
 
       expect(shipment.id).not_to eq(tracking_code)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,6 @@ Dir["./spec/support/**/*.rb"].each { |f| require f }
 
 RSpec.configure do |config|
   config.before(:each) do
-    EasyPost.api_key = 'cueqNZUb3ldeWTNX7MU3Mel8UXtaAMUi'
+    EasyPost.api_key = 'BmvaWhg8mP26QXWdTplYWA'
   end
 end


### PR DESCRIPTION
Since Ruby 2.4 was EOL'd in 2016. I vote to remove support for it and its predecessors. Anyone object?