### PR TITLE
Remove unused @@timeout and @@open_timeout from EasyPost; add README blurb on how to override default timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ Example
 require 'easypost'
 EasyPost.api_key = 'cueqNZUb3ldeWTNX7MU3Mel8UXtaAMUi'
 
+# you can configure alternate API timeouts if you want.
+EasyPost.http_config({
+  open_timeout: 15,
+  timeout: 30
+})
+
 to_address = EasyPost::Address.create(
   :name => 'Dr. Steve Brule',
   :street1 => '179 N Harbor Dr',

--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ require 'easypost'
 EasyPost.api_key = 'cueqNZUb3ldeWTNX7MU3Mel8UXtaAMUi'
 
 # you can configure alternate API timeouts if you want.
-EasyPost.http_config({
+EasyPost.http_config = {
   open_timeout: 15,
   timeout: 30
-})
+}
 
 to_address = EasyPost::Address.create(
   :name => 'Dr. Steve Brule',

--- a/lib/easypost.rb
+++ b/lib/easypost.rb
@@ -39,8 +39,6 @@ module EasyPost
   @@api_key = nil
   @@api_base = 'https://api.easypost.com/v2'
   @@api_version = nil
-  @@open_timeout = 30
-  @@timeout = 60
 
   def self.api_url(url='')
     @@api_base + url


### PR DESCRIPTION
I wanted to understand the EasyPost gem's timeout options (and see how I might configure them for my installation). I was initially thrown by the `@@timeout` and `@@open_timeout` values in the `EasyPost` module, which don't seem to be used for anything (`http_config` has hardcoded values, and that appears to be the supported way to change timeouts). I figured that removing the dead values in the module might eliminate some confusion for other folks.

Separately, I went ahead and added a small blurb to the example in the README showing how to override the default timeout settings. 