### PR TITLE
Expose http_body on the Easypost::Error object

### DIFF
--- a/lib/easypost.rb
+++ b/lib/easypost.rb
@@ -131,7 +131,7 @@ module EasyPost
 
     if (400..599).include? response.code.to_i
       error = JSON.parse(response.body)["error"]
-      raise Error.new(error["message"], response.code.to_i, error["code"], error["errors"])
+      raise Error.new(error["message"], response.code.to_i, error["code"], error["errors"], response.body)
     end
 
     if response["Content-Type"].include? "application/json"

--- a/lib/easypost/error.rb
+++ b/lib/easypost/error.rb
@@ -3,15 +3,17 @@ module EasyPost
     attr_reader :message
     attr_reader :status
     attr_reader :http_status # deprecated
+    attr_reader :http_body
     attr_reader :code
     attr_reader :errors
 
-    def initialize(message = nil, status = nil, code = nil, errors = nil)
+    def initialize(message = nil, status = nil, code = nil, errors = nil, http_body = nil)
       @message = message
       @status = status
       @http_status = status # deprecated
       @code = code
       @errors = errors
+      @http_body = http_body
 
       super(message)
     end
@@ -29,4 +31,3 @@ module EasyPost
     end
   end
 end
-

--- a/spec/cassettes/easypost/EasyPost_make_request_stores_the_http_body_on_the_error.yml
+++ b/spec/cassettes/easypost/EasyPost_make_request_stores_the_http_body_on_the_error.yml
@@ -1,0 +1,62 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.easypost.com/health/boom
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - EasyPost/v2 RubyClient/3.1.3 Ruby/2.4.4-p296
+      Content-Type:
+      - application/json
+      Authorization: "<AUTHORIZATION>"
+  response:
+    status:
+      code: 500
+      message: Internal Server Error
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Ep-Request-Uuid:
+      - '08ad24875f36b933e2002ad1000a0a2e'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, private
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Runtime:
+      - '0.253278'
+      Transfer-Encoding:
+      - chunked
+      X-Node:
+      - bigweb12sj
+      X-Version-Label:
+      - easypost-202008122048-6cdf416db1-master
+      X-Backend:
+      - easypost
+      X-Proxied:
+      - extlb2nuq 59038857a6
+      - intlb1nuq 0ab7988560
+      - intlb1sj 0ab7988560
+      Strict-Transport-Security:
+      - max-age=15768000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: '{"error":{"code":"INTERNAL_SERVER_ERROR","message":"We''re sorry, something
+        went wrong. If the problem persists please contact Support.","errors":[]}}'
+    http_version:
+  recorded_at: Fri, 14 Aug 2020 16:17:55 GMT
+recorded_with: VCR 5.1.0

--- a/spec/easypost_spec.rb
+++ b/spec/easypost_spec.rb
@@ -43,12 +43,21 @@ describe EasyPost do
       expect(response).to eq "UP"
     end
 
+    it 'stores the http_body on the error' do
+      expect { described_class.make_request("get", "/health/boom", nil) }.to raise_error(EasyPost::Error) { |error|
+        expect(error.http_body).to eq(
+          '{"error":{"code":"INTERNAL_SERVER_ERROR","message":"We\'re sorry, something went wrong. If the problem persists please contact Support.","errors":[]}}',
+        )
+      }
+    end
+
     it "raises errors for 400s" do
       expect { described_class.make_request("get", "/asdf") }.to raise_error EasyPost::Error.new(
         "The requested resource could not be found.",
         404,
         "NOT_FOUND",
-        []
+        [],
+        anything,
       )
     end
 
@@ -57,7 +66,8 @@ describe EasyPost do
         "We're sorry, something went wrong. If the problem persists please contact Support.",
         500,
         "INTERNAL_SERVER_ERROR",
-        []
+        [],
+        anything,
       )
     end
   end


### PR DESCRIPTION
Before the 3.1.x versions of this gem you could access the raw http response by calling `e.http_body`.

This PR simply adds this method back to the error object.

This is very important for debugging purposes and we're unable to upgrade to the latest version of the gem as we log every request to aid in debugging.