### PR TITLE
Prevent lowest_rate from modifying carriers and services parameters

### DIFF
--- a/lib/easypost/shipment.rb
+++ b/lib/easypost/shipment.rb
@@ -66,7 +66,7 @@ module EasyPost
 
       self.get_rates unless self.rates
 
-      carriers = carriers.is_a?(String) ? carriers.split(',') : Array(carriers)
+      carriers = carriers.is_a?(String) ? carriers.split(',') : Array(carriers).clone
       carriers.map!(&:downcase)
       carriers.map!(&:strip)
 
@@ -79,7 +79,7 @@ module EasyPost
         end
       end
 
-      services = services.is_a?(String) ? services.split(',') : Array(services)
+      services = services.is_a?(String) ? services.split(',') : Array(services).clone
       services.map!(&:downcase)
       services.map!(&:strip)
 

--- a/lib/easypost/shipment.rb
+++ b/lib/easypost/shipment.rb
@@ -66,9 +66,7 @@ module EasyPost
 
       self.get_rates unless self.rates
 
-      carriers = carriers.is_a?(String) ? carriers.split(',') : Array(carriers).clone
-      carriers.map!(&:downcase)
-      carriers.map!(&:strip)
+      carriers = EasyPost::Util.normalize_string_list(carriers)
 
       negative_carriers = []
       carriers_copy = carriers.clone
@@ -79,9 +77,7 @@ module EasyPost
         end
       end
 
-      services = services.is_a?(String) ? services.split(',') : Array(services).clone
-      services.map!(&:downcase)
-      services.map!(&:strip)
+      services = EasyPost::Util.normalize_string_list(services)
 
       negative_services = []
       services_copy = services.clone

--- a/lib/easypost/util.rb
+++ b/lib/easypost/util.rb
@@ -15,6 +15,11 @@ module EasyPost
       end
     end
 
+    def self.normalize_string_list(lst)
+      lst = lst.is_a?(String) ? lst.split(',') : Array(lst)
+      lst.map(&:to_s).map(&:downcase).map(&:strip)
+    end
+
     def self.convert_to_easypost_object(response, api_key, parent=nil, name=nil)
       types = {
         'Address' => Address,

--- a/spec/cassettes/shipment/EasyPost_Shipment_lowest_rate_domestic_shipment_doesn_t_modify_carriers_array.yml
+++ b/spec/cassettes/shipment/EasyPost_Shipment_lowest_rate_domestic_shipment_doesn_t_modify_carriers_array.yml
@@ -1,0 +1,188 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.easypost.com/v2/addresses
+    body:
+      encoding: UTF-8
+      string: '{"address":{"company":"Airport Shipping","street1":"601 Brasilia Avenue","city":"Kansas
+        City","state":"MO","zip":"64153","phone":"314-924-0383","email":"kansas_shipping@example.com"}}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - EasyPost/v2 RubyClient/3.1.3 Ruby/2.5.7-p206
+      Content-Type:
+      - application/json
+      Authorization: "<AUTHORIZATION>"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Ep-Request-Uuid:
+      - 1c9c1dd15f73c57bfb6508db00065f29
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, private
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Location:
+      - "/api/v2/addresses/adr_c9414d8b53ff4e088faa966a68fe2e02"
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Runtime:
+      - '0.063831'
+      Transfer-Encoding:
+      - chunked
+      X-Node:
+      - bigweb3sj
+      X-Version-Label:
+      - easypost-202009292141-423d229354-master
+      X-Backend:
+      - easypost
+      X-Proxied:
+      - extlb2sj a561deb64e
+      - intlb2sj 8df81f0396
+      Strict-Transport-Security:
+      - max-age=15768000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"adr_c9414d8b53ff4e088faa966a68fe2e02","object":"Address","created_at":"2020-09-29T23:38:35Z","updated_at":"2020-09-29T23:38:35Z","name":null,"company":"Airport
+        Shipping","street1":"601 Brasilia Avenue","street2":null,"city":"Kansas City","state":"MO","zip":"64153","country":"US","phone":"3149240383","email":"kansas_shipping@example.com","mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}}'
+    http_version: null
+  recorded_at: Tue, 29 Sep 2020 23:38:35 GMT
+- request:
+    method: post
+    uri: https://api.easypost.com/v2/parcels
+    body:
+      encoding: UTF-8
+      string: '{"parcel":{"width":12,"length":16.5,"height":9.5,"weight":40.1}}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - EasyPost/v2 RubyClient/3.1.3 Ruby/2.5.7-p206
+      Content-Type:
+      - application/json
+      Authorization: "<AUTHORIZATION>"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Ep-Request-Uuid:
+      - 677afd005f73c57bf53131330006290c
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, private
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Location:
+      - "/api/v2/parcels/prcl_aac079d1fb6b4cc49fd43647f29cd0e3"
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Runtime:
+      - '0.026914'
+      Transfer-Encoding:
+      - chunked
+      X-Node:
+      - bigweb12sj
+      X-Version-Label:
+      - easypost-202009292141-423d229354-master
+      X-Backend:
+      - easypost
+      X-Proxied:
+      - extlb1sj a561deb64e
+      - intlb1sj 8df81f0396
+      Strict-Transport-Security:
+      - max-age=15768000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"prcl_aac079d1fb6b4cc49fd43647f29cd0e3","object":"Parcel","created_at":"2020-09-29T23:38:35Z","updated_at":"2020-09-29T23:38:35Z","length":16.5,"width":12.0,"height":9.5,"predefined_package":null,"weight":40.1,"mode":"test"}'
+    http_version: null
+  recorded_at: Tue, 29 Sep 2020 23:38:36 GMT
+- request:
+    method: post
+    uri: https://api.easypost.com/v2/shipments
+    body:
+      encoding: UTF-8
+      string: '{"shipment":{"to_address":{"id":"adr_c9414d8b53ff4e088faa966a68fe2e02"},"from_address":{"company":"EasyPost","street1":"164
+        Townsend Street","street2":"Unit 1","city":"San Francisco","state":"CA","zip":"94107","phone":"415-123-4567"},"parcel":{"id":"prcl_aac079d1fb6b4cc49fd43647f29cd0e3"}}}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - EasyPost/v2 RubyClient/3.1.3 Ruby/2.5.7-p206
+      Content-Type:
+      - application/json
+      Authorization: "<AUTHORIZATION>"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Ep-Request-Uuid:
+      - 5e9c7bbe5f73c57cfb526d85000737f2
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, private
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Location:
+      - "/api/v2/shipments/shp_0db7263370af4a7491f6b5bf2a25887d"
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Runtime:
+      - '1.076215'
+      Transfer-Encoding:
+      - chunked
+      X-Node:
+      - bigweb12sj
+      X-Version-Label:
+      - easypost-202009292141-423d229354-master
+      X-Backend:
+      - easypost
+      X-Proxied:
+      - extlb2wdc a561deb64e
+      - intlb1sj 8df81f0396
+      - intlb1wdc 8df81f0396
+      Strict-Transport-Security:
+      - max-age=15768000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: '{"created_at":"2020-09-29T23:38:36Z","is_return":false,"messages":[],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":null,"updated_at":"2020-09-29T23:38:36Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_35459d7f72ba407f8a711bb99da71557","object":"Address","created_at":"2020-09-29T23:38:36Z","updated_at":"2020-09-29T23:38:36Z","name":null,"company":"EasyPost","street1":"164
+        Townsend Street","street2":"Unit 1","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":"4151234567","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_aac079d1fb6b4cc49fd43647f29cd0e3","object":"Parcel","created_at":"2020-09-29T23:38:35Z","updated_at":"2020-09-29T23:38:35Z","length":16.5,"width":12.0,"height":9.5,"predefined_package":null,"weight":40.1,"mode":"test"},"postage_label":null,"rates":[{"id":"rate_b1b1e53b94da42fdb16711cc5c365aa3","object":"Rate","created_at":"2020-09-29T23:38:37Z","updated_at":"2020-09-29T23:38:37Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"39.65","currency":"USD","retail_rate":"39.65","retail_currency":"USD","list_rate":"39.65","list_currency":"USD","delivery_days":6,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":6,"shipment_id":"shp_0db7263370af4a7491f6b5bf2a25887d","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},{"id":"rate_ff120dff256b4d7e8374203014aaef9d","object":"Rate","created_at":"2020-09-29T23:38:37Z","updated_at":"2020-09-29T23:38:37Z","mode":"test","service":"Express","carrier":"USPS","rate":"97.80","currency":"USD","retail_rate":"114.65","retail_currency":"USD","list_rate":"97.80","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_0db7263370af4a7491f6b5bf2a25887d","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},{"id":"rate_eb054a6cd9f94073af7dd5606c8b24ad","object":"Rate","created_at":"2020-09-29T23:38:37Z","updated_at":"2020-09-29T23:38:37Z","mode":"test","service":"Priority","carrier":"USPS","rate":"39.95","currency":"USD","retail_rate":"49.65","retail_currency":"USD","list_rate":"39.95","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_0db7263370af4a7491f6b5bf2a25887d","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},{"id":"rate_47883d4ae529463188d9ff89e04bfe53","object":"Rate","created_at":"2020-09-29T23:38:37Z","updated_at":"2020-09-29T23:38:37Z","mode":"test","service":"3DaySelect","carrier":"UPS","rate":"74.63","currency":"USD","retail_rate":"65.31","retail_currency":"USD","list_rate":"69.17","list_currency":"USD","delivery_days":3,"delivery_date":"2020-10-02T23:00:00Z","delivery_date_guaranteed":false,"est_delivery_days":3,"shipment_id":"shp_0db7263370af4a7491f6b5bf2a25887d","carrier_account_id":"ca_e63ca9a0935f4adebd2b4f287f442f02"},{"id":"rate_7ae468e066124868977def683ee42752","object":"Rate","created_at":"2020-09-29T23:38:37Z","updated_at":"2020-09-29T23:38:37Z","mode":"test","service":"NextDayAirEarlyAM","carrier":"UPS","rate":"220.40","currency":"USD","retail_rate":"206.32","retail_currency":"USD","list_rate":"208.18","list_currency":"USD","delivery_days":1,"delivery_date":"2020-09-30T08:00:00Z","delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_0db7263370af4a7491f6b5bf2a25887d","carrier_account_id":"ca_e63ca9a0935f4adebd2b4f287f442f02"},{"id":"rate_c580fb2a2f594c0b9f122936f1d85f19","object":"Rate","created_at":"2020-09-29T23:38:37Z","updated_at":"2020-09-29T23:38:37Z","mode":"test","service":"2ndDayAirAM","carrier":"UPS","rate":"134.39","currency":"USD","retail_rate":"114.05","retail_currency":"USD","list_rate":"126.90","list_currency":"USD","delivery_days":2,"delivery_date":"2020-10-01T23:00:00Z","delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_0db7263370af4a7491f6b5bf2a25887d","carrier_account_id":"ca_e63ca9a0935f4adebd2b4f287f442f02"},{"id":"rate_aaa0735134504ecc95ebfe4d31cebdbe","object":"Rate","created_at":"2020-09-29T23:38:37Z","updated_at":"2020-09-29T23:38:37Z","mode":"test","service":"Ground","carrier":"UPS","rate":"23.88","currency":"USD","retail_rate":"32.79","retail_currency":"USD","list_rate":"22.67","list_currency":"USD","delivery_days":4,"delivery_date":"2020-10-05T23:00:00Z","delivery_date_guaranteed":false,"est_delivery_days":4,"shipment_id":"shp_0db7263370af4a7491f6b5bf2a25887d","carrier_account_id":"ca_e63ca9a0935f4adebd2b4f287f442f02"},{"id":"rate_4ea9f5872ff4428685e8d0b2a8eeb978","object":"Rate","created_at":"2020-09-29T23:38:37Z","updated_at":"2020-09-29T23:38:37Z","mode":"test","service":"NextDayAirSaver","carrier":"UPS","rate":"180.29","currency":"USD","retail_rate":"155.71","retail_currency":"USD","list_rate":"168.64","list_currency":"USD","delivery_days":1,"delivery_date":"2020-09-30T23:00:00Z","delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_0db7263370af4a7491f6b5bf2a25887d","carrier_account_id":"ca_e63ca9a0935f4adebd2b4f287f442f02"},{"id":"rate_98475850a9b7408189bbf37723712d91","object":"Rate","created_at":"2020-09-29T23:38:37Z","updated_at":"2020-09-29T23:38:37Z","mode":"test","service":"NextDayAir","carrier":"UPS","rate":"189.35","currency":"USD","retail_rate":"175.27","retail_currency":"USD","list_rate":"177.13","list_currency":"USD","delivery_days":1,"delivery_date":"2020-09-30T10:30:00Z","delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_0db7263370af4a7491f6b5bf2a25887d","carrier_account_id":"ca_e63ca9a0935f4adebd2b4f287f442f02"},{"id":"rate_956aac34ef57482ca3272d3d4ff83703","object":"Rate","created_at":"2020-09-29T23:38:37Z","updated_at":"2020-09-29T23:38:37Z","mode":"test","service":"2ndDayAir","carrier":"UPS","rate":"118.56","currency":"USD","retail_rate":"99.70","retail_currency":"USD","list_rate":"110.91","list_currency":"USD","delivery_days":2,"delivery_date":"2020-10-01T23:00:00Z","delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_0db7263370af4a7491f6b5bf2a25887d","carrier_account_id":"ca_e63ca9a0935f4adebd2b4f287f442f02"}],"refund_status":null,"scan_form":null,"selected_rate":null,"tracker":null,"to_address":{"id":"adr_c9414d8b53ff4e088faa966a68fe2e02","object":"Address","created_at":"2020-09-29T23:38:35Z","updated_at":"2020-09-29T23:38:35Z","name":null,"company":"Airport
+        Shipping","street1":"601 Brasilia Avenue","street2":null,"city":"Kansas City","state":"MO","zip":"64153","country":"US","phone":"3149240383","email":"kansas_shipping@example.com","mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"usps_zone":7,"return_address":{"id":"adr_35459d7f72ba407f8a711bb99da71557","object":"Address","created_at":"2020-09-29T23:38:36Z","updated_at":"2020-09-29T23:38:36Z","name":null,"company":"EasyPost","street1":"164
+        Townsend Street","street2":"Unit 1","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":"4151234567","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_c9414d8b53ff4e088faa966a68fe2e02","object":"Address","created_at":"2020-09-29T23:38:35Z","updated_at":"2020-09-29T23:38:35Z","name":null,"company":"Airport
+        Shipping","street1":"601 Brasilia Avenue","street2":null,"city":"Kansas City","state":"MO","zip":"64153","country":"US","phone":"3149240383","email":"kansas_shipping@example.com","mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"forms":[],"fees":[],"id":"shp_0db7263370af4a7491f6b5bf2a25887d","object":"Shipment"}'
+    http_version: null
+  recorded_at: Tue, 29 Sep 2020 23:38:37 GMT
+recorded_with: VCR 5.1.0

--- a/spec/cassettes/shipment/EasyPost_Shipment_lowest_rate_domestic_shipment_doesn_t_modify_services_array.yml
+++ b/spec/cassettes/shipment/EasyPost_Shipment_lowest_rate_domestic_shipment_doesn_t_modify_services_array.yml
@@ -1,0 +1,192 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.easypost.com/v2/addresses
+    body:
+      encoding: UTF-8
+      string: '{"address":{"company":"Airport Shipping","street1":"601 Brasilia Avenue","city":"Kansas
+        City","state":"MO","zip":"64153","phone":"314-924-0383","email":"kansas_shipping@example.com"}}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - EasyPost/v2 RubyClient/3.1.3 Ruby/2.5.7-p206
+      Content-Type:
+      - application/json
+      Authorization: "<AUTHORIZATION>"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Ep-Request-Uuid:
+      - c44f720f5f73c57dfb42a3ac0006d4fd
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, private
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Location:
+      - "/api/v2/addresses/adr_2a77609cd23c4d149a2e0228172dbf77"
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Runtime:
+      - '0.046532'
+      Transfer-Encoding:
+      - chunked
+      X-Node:
+      - bigweb8sj
+      X-Version-Label:
+      - easypost-202009292141-423d229354-master
+      X-Backend:
+      - easypost
+      X-Proxied:
+      - extlb1wdc a561deb64e
+      - intlb1sj 8df81f0396
+      - intlb2wdc 8df81f0396
+      Strict-Transport-Security:
+      - max-age=15768000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"adr_2a77609cd23c4d149a2e0228172dbf77","object":"Address","created_at":"2020-09-29T23:38:38Z","updated_at":"2020-09-29T23:38:38Z","name":null,"company":"Airport
+        Shipping","street1":"601 Brasilia Avenue","street2":null,"city":"Kansas City","state":"MO","zip":"64153","country":"US","phone":"3149240383","email":"kansas_shipping@example.com","mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}}'
+    http_version: null
+  recorded_at: Tue, 29 Sep 2020 23:38:38 GMT
+- request:
+    method: post
+    uri: https://api.easypost.com/v2/parcels
+    body:
+      encoding: UTF-8
+      string: '{"parcel":{"width":12,"length":16.5,"height":9.5,"weight":40.1}}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - EasyPost/v2 RubyClient/3.1.3 Ruby/2.5.7-p206
+      Content-Type:
+      - application/json
+      Authorization: "<AUTHORIZATION>"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Ep-Request-Uuid:
+      - 70016c9b5f73c57efb66c3e90006cbbd
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, private
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Location:
+      - "/api/v2/parcels/prcl_8e519b09b68445a09822cd5f42c22ec7"
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Runtime:
+      - '0.030471'
+      Transfer-Encoding:
+      - chunked
+      X-Node:
+      - bigweb6sj
+      X-Version-Label:
+      - easypost-202009292141-423d229354-master
+      X-Backend:
+      - easypost
+      X-Proxied:
+      - extlb2nuq a561deb64e
+      - intlb2nuq 8df81f0396
+      - intlb2sj 8df81f0396
+      Strict-Transport-Security:
+      - max-age=15768000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"prcl_8e519b09b68445a09822cd5f42c22ec7","object":"Parcel","created_at":"2020-09-29T23:38:38Z","updated_at":"2020-09-29T23:38:38Z","length":16.5,"width":12.0,"height":9.5,"predefined_package":null,"weight":40.1,"mode":"test"}'
+    http_version: null
+  recorded_at: Tue, 29 Sep 2020 23:38:38 GMT
+- request:
+    method: post
+    uri: https://api.easypost.com/v2/shipments
+    body:
+      encoding: UTF-8
+      string: '{"shipment":{"to_address":{"id":"adr_2a77609cd23c4d149a2e0228172dbf77"},"from_address":{"company":"EasyPost","street1":"164
+        Townsend Street","street2":"Unit 1","city":"San Francisco","state":"CA","zip":"94107","phone":"415-123-4567"},"parcel":{"id":"prcl_8e519b09b68445a09822cd5f42c22ec7"}}}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - EasyPost/v2 RubyClient/3.1.3 Ruby/2.5.7-p206
+      Content-Type:
+      - application/json
+      Authorization: "<AUTHORIZATION>"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Ep-Request-Uuid:
+      - baecee2a5f73c57efb55cbeb0007e7c7
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, private
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Location:
+      - "/api/v2/shipments/shp_2fc5451d89b64fd9986549c986aaf7c3"
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Runtime:
+      - '2.105376'
+      Transfer-Encoding:
+      - chunked
+      X-Node:
+      - bigweb7sj
+      X-Version-Label:
+      - easypost-202009292141-423d229354-master
+      X-Backend:
+      - easypost
+      X-Canary:
+      - direct
+      X-Proxied:
+      - extlb1nuq a561deb64e
+      - intlb1sj 8df81f0396
+      - intlb2nuq 8df81f0396
+      Strict-Transport-Security:
+      - max-age=15768000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: '{"created_at":"2020-09-29T23:38:38Z","is_return":false,"messages":[],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":null,"updated_at":"2020-09-29T23:38:38Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_ca3532cac866430687f8b531bd391b19","object":"Address","created_at":"2020-09-29T23:38:38Z","updated_at":"2020-09-29T23:38:38Z","name":null,"company":"EasyPost","street1":"164
+        Townsend Street","street2":"Unit 1","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":"4151234567","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_8e519b09b68445a09822cd5f42c22ec7","object":"Parcel","created_at":"2020-09-29T23:38:38Z","updated_at":"2020-09-29T23:38:38Z","length":16.5,"width":12.0,"height":9.5,"predefined_package":null,"weight":40.1,"mode":"test"},"postage_label":null,"rates":[{"id":"rate_fc0f1e4b930a47d184eec15d929d2f52","object":"Rate","created_at":"2020-09-29T23:38:40Z","updated_at":"2020-09-29T23:38:40Z","mode":"test","service":"Express","carrier":"USPS","rate":"97.80","currency":"USD","retail_rate":"114.65","retail_currency":"USD","list_rate":"97.80","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_2fc5451d89b64fd9986549c986aaf7c3","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},{"id":"rate_37b557d73cfa44089a8fe713d591b84e","object":"Rate","created_at":"2020-09-29T23:38:40Z","updated_at":"2020-09-29T23:38:40Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"39.65","currency":"USD","retail_rate":"39.65","retail_currency":"USD","list_rate":"39.65","list_currency":"USD","delivery_days":6,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":6,"shipment_id":"shp_2fc5451d89b64fd9986549c986aaf7c3","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},{"id":"rate_f879d2b7bd3441abb88c15fbb8e13353","object":"Rate","created_at":"2020-09-29T23:38:40Z","updated_at":"2020-09-29T23:38:40Z","mode":"test","service":"Priority","carrier":"USPS","rate":"39.95","currency":"USD","retail_rate":"49.65","retail_currency":"USD","list_rate":"39.95","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_2fc5451d89b64fd9986549c986aaf7c3","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},{"id":"rate_e555b5bd6909430f9c1657fbbef8f0ed","object":"Rate","created_at":"2020-09-29T23:38:40Z","updated_at":"2020-09-29T23:38:40Z","mode":"test","service":"3DaySelect","carrier":"UPS","rate":"74.63","currency":"USD","retail_rate":"65.31","retail_currency":"USD","list_rate":"69.17","list_currency":"USD","delivery_days":3,"delivery_date":"2020-10-02T23:00:00Z","delivery_date_guaranteed":false,"est_delivery_days":3,"shipment_id":"shp_2fc5451d89b64fd9986549c986aaf7c3","carrier_account_id":"ca_e63ca9a0935f4adebd2b4f287f442f02"},{"id":"rate_f812fdfb6db745f2bbf0dba61c60ef95","object":"Rate","created_at":"2020-09-29T23:38:40Z","updated_at":"2020-09-29T23:38:40Z","mode":"test","service":"NextDayAirEarlyAM","carrier":"UPS","rate":"220.40","currency":"USD","retail_rate":"206.32","retail_currency":"USD","list_rate":"208.18","list_currency":"USD","delivery_days":1,"delivery_date":"2020-09-30T08:00:00Z","delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_2fc5451d89b64fd9986549c986aaf7c3","carrier_account_id":"ca_e63ca9a0935f4adebd2b4f287f442f02"},{"id":"rate_2f534d4edcca4af7a989ec9e303ab827","object":"Rate","created_at":"2020-09-29T23:38:40Z","updated_at":"2020-09-29T23:38:40Z","mode":"test","service":"2ndDayAirAM","carrier":"UPS","rate":"134.39","currency":"USD","retail_rate":"114.05","retail_currency":"USD","list_rate":"126.90","list_currency":"USD","delivery_days":2,"delivery_date":"2020-10-01T23:00:00Z","delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_2fc5451d89b64fd9986549c986aaf7c3","carrier_account_id":"ca_e63ca9a0935f4adebd2b4f287f442f02"},{"id":"rate_a052f24277f8477cad5b55a24c85fb05","object":"Rate","created_at":"2020-09-29T23:38:40Z","updated_at":"2020-09-29T23:38:40Z","mode":"test","service":"Ground","carrier":"UPS","rate":"23.88","currency":"USD","retail_rate":"32.79","retail_currency":"USD","list_rate":"22.67","list_currency":"USD","delivery_days":4,"delivery_date":"2020-10-05T23:00:00Z","delivery_date_guaranteed":false,"est_delivery_days":4,"shipment_id":"shp_2fc5451d89b64fd9986549c986aaf7c3","carrier_account_id":"ca_e63ca9a0935f4adebd2b4f287f442f02"},{"id":"rate_aeb168aa10d143b187dbb102cc059294","object":"Rate","created_at":"2020-09-29T23:38:40Z","updated_at":"2020-09-29T23:38:40Z","mode":"test","service":"NextDayAirSaver","carrier":"UPS","rate":"180.29","currency":"USD","retail_rate":"155.71","retail_currency":"USD","list_rate":"168.64","list_currency":"USD","delivery_days":1,"delivery_date":"2020-09-30T23:00:00Z","delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_2fc5451d89b64fd9986549c986aaf7c3","carrier_account_id":"ca_e63ca9a0935f4adebd2b4f287f442f02"},{"id":"rate_7b2f30f061b945adbadc08bac9ec26cd","object":"Rate","created_at":"2020-09-29T23:38:40Z","updated_at":"2020-09-29T23:38:40Z","mode":"test","service":"NextDayAir","carrier":"UPS","rate":"189.35","currency":"USD","retail_rate":"175.27","retail_currency":"USD","list_rate":"177.13","list_currency":"USD","delivery_days":1,"delivery_date":"2020-09-30T10:30:00Z","delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_2fc5451d89b64fd9986549c986aaf7c3","carrier_account_id":"ca_e63ca9a0935f4adebd2b4f287f442f02"},{"id":"rate_0333b8b617c2490ba1ebd104f1029166","object":"Rate","created_at":"2020-09-29T23:38:40Z","updated_at":"2020-09-29T23:38:40Z","mode":"test","service":"2ndDayAir","carrier":"UPS","rate":"118.56","currency":"USD","retail_rate":"99.70","retail_currency":"USD","list_rate":"110.91","list_currency":"USD","delivery_days":2,"delivery_date":"2020-10-01T23:00:00Z","delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_2fc5451d89b64fd9986549c986aaf7c3","carrier_account_id":"ca_e63ca9a0935f4adebd2b4f287f442f02"}],"refund_status":null,"scan_form":null,"selected_rate":null,"tracker":null,"to_address":{"id":"adr_2a77609cd23c4d149a2e0228172dbf77","object":"Address","created_at":"2020-09-29T23:38:38Z","updated_at":"2020-09-29T23:38:38Z","name":null,"company":"Airport
+        Shipping","street1":"601 Brasilia Avenue","street2":null,"city":"Kansas City","state":"MO","zip":"64153","country":"US","phone":"3149240383","email":"kansas_shipping@example.com","mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"usps_zone":7,"return_address":{"id":"adr_ca3532cac866430687f8b531bd391b19","object":"Address","created_at":"2020-09-29T23:38:38Z","updated_at":"2020-09-29T23:38:38Z","name":null,"company":"EasyPost","street1":"164
+        Townsend Street","street2":"Unit 1","city":"San Francisco","state":"CA","zip":"94107","country":"US","phone":"4151234567","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_2a77609cd23c4d149a2e0228172dbf77","object":"Address","created_at":"2020-09-29T23:38:38Z","updated_at":"2020-09-29T23:38:38Z","name":null,"company":"Airport
+        Shipping","street1":"601 Brasilia Avenue","street2":null,"city":"Kansas City","state":"MO","zip":"64153","country":"US","phone":"3149240383","email":"kansas_shipping@example.com","mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"forms":[],"fees":[],"id":"shp_2fc5451d89b64fd9986549c986aaf7c3","object":"Shipment"}'
+    http_version: null
+  recorded_at: Tue, 29 Sep 2020 23:38:40 GMT
+recorded_with: VCR 5.1.0

--- a/spec/shipment_spec.rb
+++ b/spec/shipment_spec.rb
@@ -115,26 +115,28 @@ describe EasyPost::Shipment do
 
   describe '#lowest_rate' do
     context 'domestic shipment' do
-      it 'filters negative services' do
-        shipment = EasyPost::Shipment.create(
+      let (:shipment) {
+        EasyPost::Shipment.create(
           to_address: EasyPost::Address.create(ADDRESS[:missouri]),
           from_address: ADDRESS[:california],
           parcel: EasyPost::Parcel.create(PARCEL[:dimensions])
         )
+      }
 
+      it 'filters negative services' do
         rate = shipment.lowest_rate('USPS', '!MediaMail, !LibraryMail')
         expect(rate.service).to eql('ParcelSelect')
       end
 
       it 'doesn\'t modify carriers array' do
         carriers = %w(USPS)
-        @shipment.lowest_rate(carriers)
+        shipment.lowest_rate(carriers)
         expect(carriers).to eq(%w(USPS))
       end
 
       it 'doesn\'t modify services array' do
         services = %w(ParcelSelect)
-        @shipment.lowest_rate('USPS', services)
+        shipment.lowest_rate('USPS', services)
         expect(services).to eq(%w(ParcelSelect))
       end
     end

--- a/spec/shipment_spec.rb
+++ b/spec/shipment_spec.rb
@@ -125,6 +125,18 @@ describe EasyPost::Shipment do
         rate = shipment.lowest_rate('USPS', '!MediaMail, !LibraryMail')
         expect(rate.service).to eql('ParcelSelect')
       end
+
+      it 'doesn\'t modify carriers array' do
+        carriers = %w(USPS)
+        @shipment.lowest_rate(carriers)
+        expect(carriers).to eq(%w(USPS))
+      end
+
+      it 'doesn\'t modify services array' do
+        services = %w(ParcelSelect)
+        @shipment.lowest_rate('USPS', services)
+        expect(services).to eq(%w(ParcelSelect))
+      end
     end
   end
 

--- a/spec/util_spec.rb
+++ b/spec/util_spec.rb
@@ -1,0 +1,17 @@
+require "spec_helper"
+
+describe EasyPost::Util do
+  describe "#normalize_string_list" do
+    it "handles a pre-normalized list" do
+      expect(EasyPost::Util.normalize_string_list(["foo", "bar", "baz"])).to eq ["foo", "bar", "baz"]
+    end
+
+    it "handles comma-separated strings" do
+      expect(EasyPost::Util.normalize_string_list("foo,bar,Baz")).to eq ["foo", "bar", "baz"]
+    end
+
+    it "handles symbols" do
+      expect(EasyPost::Util.normalize_string_list([:foo, :bar, :baz])).to eq ["foo", "bar", "baz"]
+    end
+  end
+end


### PR DESCRIPTION
This is some fixes on top of #71 to make it work a bit more cleanly.

Closes #71.