### PR TITLE
flatten all classes and modules; fully-qualify scopes

### DIFF
--- a/lib/easypost.rb
+++ b/lib/easypost.rb
@@ -118,7 +118,7 @@ module EasyPost
 
     request = Net::HTTP.const_get(method.capitalize).new(path)
     if body
-      request.body = JSON.dump(Util.objects_to_ids(body))
+      request.body = JSON.dump(EasyPost::Util.objects_to_ids(body))
     end
 
     request["Content-Type"] = "application/json"
@@ -131,7 +131,7 @@ module EasyPost
 
     if (400..599).include? response.code.to_i
       error = JSON.parse(response.body)["error"]
-      raise Error.new(error["message"], response.code.to_i, error["code"], error["errors"], response.body)
+      raise EasyPost::Error.new(error["message"], response.code.to_i, error["code"], error["errors"], response.body)
     end
 
     if response["Content-Type"].include? "application/json"

--- a/lib/easypost/address.rb
+++ b/lib/easypost/address.rb
@@ -1,60 +1,58 @@
-module EasyPost
-  class Address < Resource
-    attr_accessor :message # Backwards compatibility
+class EasyPost::Address < EasyPost::Resource
+  attr_accessor :message # Backwards compatibility
 
-    def self.create(params={}, api_key=nil)
-      url = self.url
+  def self.create(params={}, api_key=nil)
+    url = self.url
 
-      address = params.reject { |k,_| k == :verify || k == :verify_strict }
-      
-      if params[:verify] || params[:verify_strict]
-        verify = params[:verify] || []
-        verify_strict = params[:verify_strict] || []
+    address = params.reject { |k,_| k == :verify || k == :verify_strict }
 
-        url += "?"
-        verify.each do |verification|
-          url += "verify[]=#{verification}&"
-        end
-        verify_strict.each do |verification|
-          url += "verify_strict[]=#{verification}&"
-        end
+    if params[:verify] || params[:verify_strict]
+      verify = params[:verify] || []
+      verify_strict = params[:verify_strict] || []
+
+      url += "?"
+      verify.each do |verification|
+        url += "verify[]=#{verification}&"
       end
-
-      response = EasyPost.make_request(:post, url, api_key, {address: address})
-      return Util.convert_to_easypost_object(response, api_key)
-    end
-
-    def self.create_and_verify(params={}, carrier=nil, api_key=nil)
-      wrapped_params = {}
-      wrapped_params[self.class_name().to_sym] = params
-      wrapped_params[:carrier] = carrier
-      response = EasyPost.make_request(:post, url + '/create_and_verify', api_key, wrapped_params)
-
-      if response.has_key?(:address)
-        if response.has_key?(:message)
-          response[:address][:message] = response[:message]
-        end
-        verified_address = EasyPost::Util::convert_to_easypost_object(response[:address], api_key)
-        return verified_address
-      else
-        raise Error.new("Unable to verify address.")
+      verify_strict.each do |verification|
+        url += "verify_strict[]=#{verification}&"
       end
     end
 
-    def verify(params={}, carrier=nil)
-      begin
-        response = EasyPost.make_request(:get, url + '/verify?carrier=' + String(carrier), @api_key, params)
-      rescue
-        raise Error.new("Unable to verify address.")
-      end
+    response = EasyPost.make_request(:post, url, api_key, {address: address})
+    return EasyPost::Util.convert_to_easypost_object(response, api_key)
+  end
 
-      if response.has_key?("address")
-        return EasyPost::Util::convert_to_easypost_object(response["address"], api_key)
-      else
-        raise Error.new("Unable to verify address.")
-      end
+  def self.create_and_verify(params={}, carrier=nil, api_key=nil)
+    wrapped_params = {}
+    wrapped_params[self.class_name().to_sym] = params
+    wrapped_params[:carrier] = carrier
+    response = EasyPost.make_request(:post, url + '/create_and_verify', api_key, wrapped_params)
 
-      return self
+    if response.has_key?(:address)
+      if response.has_key?(:message)
+        response[:address][:message] = response[:message]
+      end
+      verified_address = EasyPost::Util::convert_to_easypost_object(response[:address], api_key)
+      return verified_address
+    else
+      raise EasyPost::Error.new("Unable to verify address.")
     end
+  end
+
+  def verify(params={}, carrier=nil)
+    begin
+      response = EasyPost.make_request(:get, url + '/verify?carrier=' + String(carrier), @api_key, params)
+    rescue
+      raise EasyPost::Error.new("Unable to verify address.")
+    end
+
+    if response.has_key?("address")
+      return EasyPost::Util::convert_to_easypost_object(response["address"], api_key)
+    else
+      raise EasyPost::Error.new("Unable to verify address.")
+    end
+
+    return self
   end
 end

--- a/lib/easypost/batch.rb
+++ b/lib/easypost/batch.rb
@@ -1,53 +1,49 @@
-module EasyPost
-  class Batch < Resource
+class EasyPost::Batch < EasyPost::Resource
+  def self.create_and_buy(params={}, api_key=nil)
+    wrapped_params = {}
+    wrapped_params[self.class_name().to_sym] = params
+    response = EasyPost.make_request(:post, url + '/create_and_buy', api_key, wrapped_params)
 
-    def self.create_and_buy(params={}, api_key=nil)
-      wrapped_params = {}
-      wrapped_params[self.class_name().to_sym] = params
-      response = EasyPost.make_request(:post, url + '/create_and_buy', api_key, wrapped_params)
+    return EasyPost::Util.convert_to_easypost_object(response, api_key)
+  end
 
-      return Util.convert_to_easypost_object(response, api_key)
-    end
+  def buy(params={})
+    response = EasyPost.make_request(:post, url + '/buy', @api_key, params)
+    self.refresh_from(response, @api_key, true)
 
-    def buy(params={})
-      response = EasyPost.make_request(:post, url + '/buy', @api_key, params)
-      self.refresh_from(response, @api_key, true)
+    return self
+  end
 
-      return self
-    end
+  def label(params={})
+    response = EasyPost.make_request(:post, url + '/label', @api_key, params)
+    self.refresh_from(response, @api_key, true)
 
-    def label(params={})
-      response = EasyPost.make_request(:post, url + '/label', @api_key, params)
-      self.refresh_from(response, @api_key, true)
+    return self
+  end
 
-      return self
-    end
+  def remove_shipments(params={})
+    response = EasyPost.make_request(:post, url + '/remove_shipments', @api_key, params)
+    self.refresh_from(response, @api_key, true)
 
-    def remove_shipments(params={})
-      response = EasyPost.make_request(:post, url + '/remove_shipments', @api_key, params)
-      self.refresh_from(response, @api_key, true)
+    return self
+  end
 
-      return self
-    end
+  def add_shipments(params={})
+    response = EasyPost.make_request(:post, url + '/add_shipments', @api_key, params)
+    self.refresh_from(response, @api_key, true)
 
-    def add_shipments(params={})
-      response = EasyPost.make_request(:post, url + '/add_shipments', @api_key, params)
-      self.refresh_from(response, @api_key, true)
+    return self
+  end
 
-      return self
-    end
+  def stamp_and_barcode_by_reference(params={})
+    response = EasyPost.make_request(:get, url + '/stamp_and_barcode_by_reference', @api_key, params)
 
-    def stamp_and_barcode_by_reference(params={})
-      response = EasyPost.make_request(:get, url + '/stamp_and_barcode_by_reference', @api_key, params)
+    return response
+  end
 
-      return response
-    end
+  def create_scan_form(params={})
+    response = EasyPost.make_request(:post, url + '/scan_form', @api_key, params)
 
-    def create_scan_form(params={})
-      response = EasyPost.make_request(:post, url + '/scan_form', @api_key, params)
-
-      return response
-    end
-
+    return response
   end
 end

--- a/lib/easypost/carrier_account.rb
+++ b/lib/easypost/carrier_account.rb
@@ -1,8 +1,6 @@
-module EasyPost
-  class CarrierAccount < Resource
-    def self.types
-      response = EasyPost.make_request(:get, "/carrier_types", @api_key)
-      return Util.convert_to_easypost_object(response, api_key)
-    end
+class EasyPost::CarrierAccount < EasyPost::Resource
+  def self.types
+    response = EasyPost.make_request(:get, "/carrier_types", @api_key)
+    return EasyPost::Util.convert_to_easypost_object(response, api_key)
   end
 end

--- a/lib/easypost/customs_info.rb
+++ b/lib/easypost/customs_info.rb
@@ -1,9 +1,5 @@
-module EasyPost
-  class CustomsInfo < Resource
-
-    def self.all(filters={}, api_key=nil)
-      raise NotImplementedError.new('CustomsInfo.all not implemented.')
-    end
-
+class EasyPost::CustomsInfo < EasyPost::Resource
+  def self.all(filters={}, api_key=nil)
+    raise NotImplementedError.new('CustomsInfo.all not implemented.')
   end
 end

--- a/lib/easypost/customs_item.rb
+++ b/lib/easypost/customs_item.rb
@@ -1,9 +1,5 @@
-module EasyPost
-  class CustomsItem < Resource
-
-    def self.all(filters={}, api_key=nil)
-      raise NotImplementedError.new('CustomsItem.all not implemented.')
-    end
-
+class EasyPost::CustomsItem < EasyPost::Resource
+  def self.all(filters={}, api_key=nil)
+    raise NotImplementedError.new('CustomsItem.all not implemented.')
   end
 end

--- a/lib/easypost/error.rb
+++ b/lib/easypost/error.rb
@@ -1,33 +1,31 @@
-module EasyPost
-  class Error < StandardError
-    attr_reader :message
-    attr_reader :status
-    attr_reader :http_status # deprecated
-    attr_reader :http_body
-    attr_reader :code
-    attr_reader :errors
+class EasyPost::Error < StandardError
+  attr_reader :message
+  attr_reader :status
+  attr_reader :http_status # deprecated
+  attr_reader :http_body
+  attr_reader :code
+  attr_reader :errors
 
-    def initialize(message = nil, status = nil, code = nil, errors = nil, http_body = nil)
-      @message = message
-      @status = status
-      @http_status = status # deprecated
-      @code = code
-      @errors = errors
-      @http_body = http_body
+  def initialize(message = nil, status = nil, code = nil, errors = nil, http_body = nil)
+    @message = message
+    @status = status
+    @http_status = status # deprecated
+    @code = code
+    @errors = errors
+    @http_body = http_body
 
-      super(message)
-    end
+    super(message)
+  end
 
-    def to_s
-      "#{code} (#{status}): #{message} #{errors}".strip
-    end
+  def to_s
+    "#{code} (#{status}): #{message} #{errors}".strip
+  end
 
-    def ==(other)
-      other.is_a?(Error) &&
-        message == other.message &&
-        status == other.status &&
-        code == other.code &&
-        errors == other.errors
-    end
+  def ==(other)
+    other.is_a?(EasyPost::Error) &&
+      message == other.message &&
+      status == other.status &&
+      code == other.code &&
+      errors == other.errors
   end
 end

--- a/lib/easypost/event.rb
+++ b/lib/easypost/event.rb
@@ -1,10 +1,7 @@
 require 'json'
 
-module EasyPost
-  class Event < Resource
-      
-    def self.receive(values)
-        return EasyPost::Util::convert_to_easypost_object(JSON.parse(values), nil)
-    end
+class EasyPost::Event < EasyPost::Resource
+  def self.receive(values)
+      return EasyPost::Util::convert_to_easypost_object(JSON.parse(values), nil)
   end
 end

--- a/lib/easypost/insurance.rb
+++ b/lib/easypost/insurance.rb
@@ -1,4 +1,2 @@
-module EasyPost
-  class Insurance < Resource
-  end
+class EasyPost::Insurance < EasyPost::Resource
 end

--- a/lib/easypost/item.rb
+++ b/lib/easypost/item.rb
@@ -1,10 +1,6 @@
-module EasyPost
-  class Item < Resource
-
-    def self.retrieve_reference(params={}, api_key=nil)
-      response = EasyPost.make_request(:get, url + '/retrieve_reference', api_key, params)
-      return EasyPost::Util::convert_to_easypost_object(response, api_key) if response
-    end
-
+class EasyPost::Item < EasyPost::Resource
+  def self.retrieve_reference(params={}, api_key=nil)
+    response = EasyPost.make_request(:get, url + '/retrieve_reference', api_key, params)
+    return EasyPost::Util::convert_to_easypost_object(response, api_key) if response
   end
 end

--- a/lib/easypost/object.rb
+++ b/lib/easypost/object.rb
@@ -1,147 +1,144 @@
 require "set"
 
-module EasyPost
-  class EasyPostObject
-    include Enumerable
+class EasyPost::EasyPostObject
+  include Enumerable
 
-    attr_accessor :parent, :name, :api_key, :unsaved_values
-    @@immutable_values = Set.new([:api_key, :id])
+  attr_accessor :parent, :name, :api_key, :unsaved_values
+  @@immutable_values = Set.new([:api_key, :id])
 
-    def initialize(id=nil, api_key=nil, parent=nil, name=nil)
-      @api_key = api_key
-      @values = {}
-      @unsaved_values = Set.new
-      @transient_values = Set.new
-      @parent = parent
-      @name = name
-      self.id = id if id
+  def initialize(id=nil, api_key=nil, parent=nil, name=nil)
+    @api_key = api_key
+    @values = {}
+    @unsaved_values = Set.new
+    @transient_values = Set.new
+    @parent = parent
+    @name = name
+    self.id = id if id
+  end
+
+  def self.construct_from(values, api_key=nil, parent=nil, name=nil)
+    obj = self.new(values[:id], api_key, parent, name)
+    obj.refresh_from(values, api_key)
+    obj
+  end
+
+  def to_s(*args)
+    JSON.dump(@values)
+  end
+
+  def inspect
+    id_string = (self.respond_to?(:id) && !self.id.nil?) ? " id=#{self.id}" : ""
+    "#<#{self.class}:#{id_string}> JSON: " + to_json
+  end
+
+  def refresh_from(values, api_key, partial=false)
+    @api_key = api_key
+
+    added = Set.new(values.keys - @values.keys)
+
+    instance_eval do
+      add_accessors(added)
     end
 
-    def self.construct_from(values, api_key=nil, parent=nil, name=nil)
-      obj = self.new(values[:id], api_key, parent, name)
-      obj.refresh_from(values, api_key)
-      obj
+    values.each do |k, v|
+      @values[k.to_s] = EasyPost::Util.convert_to_easypost_object(v, api_key, self, k)
+      @transient_values.delete(k)
+      @unsaved_values.delete(k)
     end
+  end
 
-    def to_s(*args)
-      JSON.dump(@values)
-    end
+  def [](k)
+    @values[k.to_s]
+  end
 
-    def inspect
-      id_string = (self.respond_to?(:id) && !self.id.nil?) ? " id=#{self.id}" : ""
-      "#<#{self.class}:#{id_string}> JSON: " + to_json
-    end
+  def []=(k, v)
+    send(:"#{k}=", v)
+  end
 
-    def refresh_from(values, api_key, partial=false)
-      @api_key = api_key
+  def keys
+    @values.keys
+  end
 
-      added = Set.new(values.keys - @values.keys)
+  def values
+    @values.values
+  end
 
-      instance_eval do
-        add_accessors(added)
-      end
+  def to_json(options = {})
+    JSON.dump(@values)
+  end
 
-      values.each do |k, v|
-        @values[k.to_s] = Util.convert_to_easypost_object(v, api_key, self, k)
-        @transient_values.delete(k)
-        @unsaved_values.delete(k)
-      end
-    end
+  def as_json(options = {})
+    @values.as_json
+  end
 
-    def [](k)
-      @values[k.to_s]
-    end
+  def to_hash
+    @values
+  end
 
-    def []=(k, v)
-      send(:"#{k}=", v)
-    end
+  def each(&blk)
+    @values.each(&blk)
+  end
 
-    def keys
-      @values.keys
-    end
+  def id=(id)
+    @values[:id] = id
+  end
 
-    def values
-      @values.values
-    end
+  def id
+    @values[:id]
+  end
 
-    def to_json(options = {})
-      JSON.dump(@values)
-    end
+  protected
 
-    def as_json(options = {})
-      @values.as_json
-    end
+  def flatten_unsaved
+    values = {}
+    for key in @unsaved_values
+      value = @values[key]
 
-    def to_hash
-      @values
-    end
+      values[key] = value
 
-    def each(&blk)
-      @values.each(&blk)
-    end
-
-    def id=(id)
-      @values[:id] = id
-    end
-
-    def id
-      @values[:id]
-    end
-
-    protected
-
-    def flatten_unsaved
-      values = {}
-      for key in @unsaved_values
-        value = @values[key]
-
-        values[key] = value
-
-        if value.is_a?(EasyPost::EasyPostObject)
-          values[key] = flatten_unsaved(value)
-        end
-      end
-
-      return values
-    end
-
-    def metaclass
-      class << self; self; end
-    end
-
-    def remove_accessors(keys)
-      metaclass.instance_eval do
-        keys.each do |k|
-          next if @@immutable_values.include?(k)
-          k_eq = :"#{k}="
-          remove_method(k) if method_defined?(k)
-          remove_method(k_eq) if method_defined?(k_eq)
-        end
+      if value.is_a?(EasyPost::EasyPostObject)
+        values[key] = flatten_unsaved(value)
       end
     end
 
-    def add_accessors(keys)
-      metaclass.instance_eval do
-        keys.each do |k|
-          k = k.to_s
-          next if @@immutable_values.include?(k)
-          k_eq = :"#{k}="
-          define_method(k) { @values[k] }
-          define_method(k_eq) do |v|
-            @values[k] = v
-            @unsaved_values.add(k)
+    return values
+  end
 
-            cur = self
-            cur_parent = self.parent
+  def metaclass
+    class << self; self; end
+  end
 
-            while cur_parent
-              if cur.name
-                cur_parent.unsaved_values.add(cur.name)
-              end
+  def remove_accessors(keys)
+    metaclass.instance_eval do
+      keys.each do |k|
+        next if @@immutable_values.include?(k)
+        k_eq = :"#{k}="
+        remove_method(k) if method_defined?(k)
+        remove_method(k_eq) if method_defined?(k_eq)
+      end
+    end
+  end
 
-              cur = cur_parent
-              cur_parent = cur.parent
+  def add_accessors(keys)
+    metaclass.instance_eval do
+      keys.each do |k|
+        next if @@immutable_values.include?(k)
+        k = k.to_s
+        k_eq = :"#{k}="
+        define_method(k) { @values[k] }
+        define_method(k_eq) do |v|
+          @values[k] = v
+          @unsaved_values.add(k)
+
+          cur = self
+          cur_parent = self.parent
+          while cur_parent
+            if cur.name
+              cur_parent.unsaved_values.add(cur.name)
             end
+
+            cur = cur_parent
+            cur_parent = cur.parent
           end
         end
       end

--- a/lib/easypost/order.rb
+++ b/lib/easypost/order.rb
@@ -1,30 +1,28 @@
-module EasyPost
-  class Order < Resource
+class EasyPost::Order < EasyPost::Resource
 
-    def get_rates(params={})
-      response = EasyPost.make_request(:get, url + '/rates', @api_key, params)
-      self.refresh_from(response, @api_key, true)
+  def get_rates(params={})
+    response = EasyPost.make_request(:get, url + '/rates', @api_key, params)
+    self.refresh_from(response, @api_key, true)
 
-      return self
-    end
-
-    def buy(params={})
-      if params.instance_of?(EasyPost::Rate)
-        temp = params.clone
-        params = {}
-        params[:carrier] = temp.carrier
-        params[:service] = temp.service
-      end
-
-      response = EasyPost.make_request(:post, url + '/buy', @api_key, params)
-      self.refresh_from(response, @api_key, true)
-
-      return self
-    end
-
-    def self.all(filters={}, api_key=nil)
-      raise NotImplementedError.new('Order.all not implemented.')
-    end
-
+    return self
   end
+
+  def buy(params={})
+    if params.instance_of?(EasyPost::Rate)
+      temp = params.clone
+      params = {}
+      params[:carrier] = temp.carrier
+      params[:service] = temp.service
+    end
+
+    response = EasyPost.make_request(:post, url + '/buy', @api_key, params)
+    self.refresh_from(response, @api_key, true)
+
+    return self
+  end
+
+  def self.all(filters={}, api_key=nil)
+    raise NotImplementedError.new('Order.all not implemented.')
+  end
+
 end

--- a/lib/easypost/parcel.rb
+++ b/lib/easypost/parcel.rb
@@ -1,4 +1,2 @@
-module EasyPost
-  class Parcel < Resource
-  end
+class EasyPost::Parcel < EasyPost::Resource
 end

--- a/lib/easypost/pickup.rb
+++ b/lib/easypost/pickup.rb
@@ -1,30 +1,26 @@
-module EasyPost
-  class Pickup < Resource
-
-    def buy(params={})
-      if params.instance_of?(EasyPost::PickupRate)
-        temp = params.clone
-        params = {}
-        params[:carrier] = temp.carrier
-        params[:service] = temp.service
-      end
-
-      response = EasyPost.make_request(:post, url + '/buy', @api_key, params)
-      self.refresh_from(response, @api_key, true)
-
-      return self
+class EasyPost::Pickup < EasyPost::Resource
+  def buy(params={})
+    if params.instance_of?(EasyPost::PickupRate)
+      temp = params.clone
+      params = {}
+      params[:carrier] = temp.carrier
+      params[:service] = temp.service
     end
 
-    def cancel(params={})
-      response = EasyPost.make_request(:post, url + '/cancel', @api_key, params)
-      self.refresh_from(response, @api_key, true)
+    response = EasyPost.make_request(:post, url + '/buy', @api_key, params)
+    self.refresh_from(response, @api_key, true)
 
-      return self
-    end
+    return self
+  end
 
-    def self.all(filters={}, api_key=nil)
-      raise NotImplementedError.new('Pickup.all not implemented.')
-    end
+  def cancel(params={})
+    response = EasyPost.make_request(:post, url + '/cancel', @api_key, params)
+    self.refresh_from(response, @api_key, true)
 
+    return self
+  end
+
+  def self.all(filters={}, api_key=nil)
+    raise NotImplementedError.new('Pickup.all not implemented.')
   end
 end

--- a/lib/easypost/pickup_rate.rb
+++ b/lib/easypost/pickup_rate.rb
@@ -1,5 +1,3 @@
-module EasyPost
-  class PickupRate < Resource
+class EasyPost::PickupRate < EasyPost::Resource
 
-  end
 end

--- a/lib/easypost/postage_label.rb
+++ b/lib/easypost/postage_label.rb
@@ -1,4 +1,2 @@
-module EasyPost
-  class PostageLabel < Resource
-  end
+class EasyPost::PostageLabel < EasyPost::Resource
 end

--- a/lib/easypost/print_job.rb
+++ b/lib/easypost/print_job.rb
@@ -1,6 +1,2 @@
-module EasyPost
-  class PrintJob < Resource
-  end
+class EasyPost::PrintJob < EasyPost::Resource
 end
-
-

--- a/lib/easypost/printer.rb
+++ b/lib/easypost/printer.rb
@@ -1,28 +1,24 @@
-module EasyPost
-  class Printer < Resource
+class EasyPost::Printer < EasyPost::Resource
 
-    def job
-      response = EasyPost.make_request(
-        :get, url + '/jobs', @api_key
-      )
-      return EasyPost::Util::convert_to_easypost_object(response, api_key)
+  def job
+    response = EasyPost.make_request(
+      :get, url + '/jobs', @api_key
+    )
+    return EasyPost::Util::convert_to_easypost_object(response, api_key)
+  end
+
+  def print(params={})
+    if params.instance_of?(EasyPost::PostageLabel)
+      temp = params.clone
+      params = {}
+      params[:postage_label] = temp
     end
 
-    def print(params={})
-      if params.instance_of?(EasyPost::PostageLabel)
-        temp = params.clone
-        params = {}
-        params[:postage_label] = temp
-      end
-
-      response = EasyPost.make_request(
-        :post, url + '/print_postage_label', @api_key, params
-      )
-      return true
-    rescue
-      return false
-    end
-
+    response = EasyPost.make_request(
+      :post, url + '/print_postage_label', @api_key, params
+    )
+    true
+  rescue
+    false
   end
 end
-

--- a/lib/easypost/rate.rb
+++ b/lib/easypost/rate.rb
@@ -1,4 +1,2 @@
-module EasyPost
-  class Rate < Resource
-  end
+class EasyPost::Rate < EasyPost::Resource
 end

--- a/lib/easypost/refund.rb
+++ b/lib/easypost/refund.rb
@@ -1,4 +1,2 @@
-module EasyPost
-  class Refund < Resource
-  end
+class EasyPost::Refund < EasyPost::Resource
 end

--- a/lib/easypost/report.rb
+++ b/lib/easypost/report.rb
@@ -1,31 +1,29 @@
-module EasyPost
-  class Report < Resource
-    def self.create(params={}, api_key=nil)
-      url = "#{self.url}/#{params[:type]}"
-      wrapped_params = {}
-      wrapped_params[class_name.to_sym] = params
+class EasyPost::Report < EasyPost::Resource
+  def self.create(params={}, api_key=nil)
+    url = "#{self.url}/#{params[:type]}"
+    wrapped_params = {}
+    wrapped_params[class_name.to_sym] = params
 
-      response = EasyPost.make_request(:post, url, api_key, params)
-      return Util.convert_to_easypost_object(response, api_key)
+    response = EasyPost.make_request(:post, url, api_key, params)
+    return EasyPost::Util.convert_to_easypost_object(response, api_key)
+  end
+
+  def self.retrieve(params, api_key=nil)
+    id = if params.is_a?(String)
+      params
+    else
+      params[:id]
     end
 
-    def self.retrieve(params, api_key=nil)
-      id = if params.is_a?(String)
-        params
-      else
-        params[:id]
-      end
+    instance = self.new(id, api_key)
+    instance.refresh
+    return instance
+  end
 
-      instance = self.new(id, api_key)
-      instance.refresh
-      return instance
-    end
+  def self.all(filters={}, api_key=nil)
+    url = "#{self.url}/#{filters[:type]}"
 
-    def self.all(filters={}, api_key=nil)
-      url = "#{self.url}/#{filters[:type]}"
-
-      response = EasyPost.make_request(:get, url, api_key, filters)
-      return EasyPost::Util::convert_to_easypost_object(response, api_key) if response
-    end
+    response = EasyPost.make_request(:get, url, api_key, filters)
+    return EasyPost::Util::convert_to_easypost_object(response, api_key) if response
   end
 end

--- a/lib/easypost/resource.rb
+++ b/lib/easypost/resource.rb
@@ -1,77 +1,75 @@
-module EasyPost
-  class Resource < EasyPostObject
-    def self.class_name
-      camel = self.name.split('::')[-1]
-      snake = camel[0..0] + camel[1..-1].gsub(/([A-Z])/, '_\1')
-      return snake.downcase
+class EasyPost::Resource < EasyPost::EasyPostObject
+  def self.class_name
+    camel = self.name.split('::')[-1]
+    snake = camel[0..0] + camel[1..-1].gsub(/([A-Z])/, '_\1')
+    return snake.downcase
+  end
+
+  def self.url
+    if self.class_name == 'resource'
+      raise NotImplementedError.new('Resource is an abstract class.  You should perform actions on its subclasses (Address, Shipment, etc.)')
     end
-
-    def self.url
-      if self.class_name == 'resource'
-        raise NotImplementedError.new('Resource is an abstract class.  You should perform actions on its subclasses (Address, Shipment, etc.)')
-      end
-      if(self.class_name[-1..-1] == 's' || self.class_name[-1..-1] == 'h')
-        return "/v2/#{CGI.escape(self.class_name.downcase)}es"
-      else
-        return "/v2/#{CGI.escape(class_name.downcase)}s"
-      end
+    if(self.class_name[-1..-1] == 's' || self.class_name[-1..-1] == 'h')
+      return "/v2/#{CGI.escape(self.class_name.downcase)}es"
+    else
+      return "/v2/#{CGI.escape(class_name.downcase)}s"
     end
+  end
 
-    def url
-      unless self.id
-        raise Error.new("Could not determine which URL to request: #{self.class} instance has invalid ID: #{self.id.inspect}")
-      end
-      return "#{self.class.url}/#{CGI.escape(id)}"
+  def url
+    unless self.id
+      raise EasyPost::Error.new("Could not determine which URL to request: #{self.class} instance has invalid ID: #{self.id.inspect}")
     end
+    return "#{self.class.url}/#{CGI.escape(id)}"
+  end
 
-    def refresh
-      response = EasyPost.make_request(:get, url, @api_key, @retrieve_options)
-      refresh_from(response, api_key)
-      return self
-    end
+  def refresh
+    response = EasyPost.make_request(:get, url, @api_key, @retrieve_options)
+    refresh_from(response, api_key)
+    return self
+  end
 
-    def self.all(filters={}, api_key=nil)
-      response = EasyPost.make_request(:get, url, api_key, filters)
-      return Util.convert_to_easypost_object(response, api_key)
-    end
+  def self.all(filters={}, api_key=nil)
+    response = EasyPost.make_request(:get, url, api_key, filters)
+    return EasyPost::Util.convert_to_easypost_object(response, api_key)
+  end
 
-    def self.retrieve(id, api_key=nil)
-      instance = self.new(id, api_key)
-      instance.refresh
-      return instance
-    end
+  def self.retrieve(id, api_key=nil)
+    instance = self.new(id, api_key)
+    instance.refresh
+    return instance
+  end
 
-    def self.create(params={}, api_key=nil)
-      wrapped_params = {}
-      wrapped_params[self.class_name().to_sym] = params
-      response = EasyPost.make_request(:post, self.url, api_key, wrapped_params)
-      return Util.convert_to_easypost_object(response, api_key)
-    end
+  def self.create(params={}, api_key=nil)
+    wrapped_params = {}
+    wrapped_params[self.class_name().to_sym] = params
+    response = EasyPost.make_request(:post, self.url, api_key, wrapped_params)
+    return EasyPost::Util.convert_to_easypost_object(response, api_key)
+  end
 
-    def delete
-      response = EasyPost.make_request(:delete, url, @api_key)
-      refresh_from(response, api_key)
-      return self
-    end
+  def delete
+    response = EasyPost.make_request(:delete, url, @api_key)
+    refresh_from(response, api_key)
+    return self
+  end
 
-    def save
-      if @unsaved_values.length > 0
-        values = {}
-        @unsaved_values.each { |k| values[k] = @values[k] }
+  def save
+    if @unsaved_values.length > 0
+      values = {}
+      @unsaved_values.each { |k| values[k] = @values[k] }
 
-        for key in @unsaved_values
-          value = values[key]
-          if value.is_a?(EasyPost::EasyPostObject)
-            values[key] = value.flatten_unsaved
-          end
+      for key in @unsaved_values
+        value = values[key]
+        if value.is_a?(EasyPost::EasyPostObject)
+          values[key] = value.flatten_unsaved
         end
-
-        wrapped_params = {self.class.class_name => values}
-
-        response = EasyPost.make_request(:put, url, @api_key, wrapped_params)
-        refresh_from(response, api_key)
       end
-      return self
+
+      wrapped_params = {self.class.class_name => values}
+
+      response = EasyPost.make_request(:put, url, @api_key, wrapped_params)
+      refresh_from(response, api_key)
     end
+    return self
   end
 end

--- a/lib/easypost/scan_form.rb
+++ b/lib/easypost/scan_form.rb
@@ -1,8 +1,6 @@
-module EasyPost
-  class ScanForm < Resource
-    def self.create(params={}, api_key=nil)
-      response = EasyPost.make_request(:post, self.url, api_key, params)
-      return Util.convert_to_easypost_object(response, api_key)
-    end
+class EasyPost::ScanForm < EasyPost::Resource
+  def self.create(params={}, api_key=nil)
+    response = EasyPost.make_request(:post, self.url, api_key, params)
+    return EasyPost::Util.convert_to_easypost_object(response, api_key)
   end
 end

--- a/lib/easypost/shipment.rb
+++ b/lib/easypost/shipment.rb
@@ -1,120 +1,116 @@
-module EasyPost
-  class Shipment < Resource
+class EasyPost::Shipment < EasyPost::Resource
+  def get_rates(params={})
+    response = EasyPost.make_request(:get, url + '/rates', @api_key, params)
+    self.refresh_from(response, @api_key, true)
 
-    def get_rates(params={})
-      response = EasyPost.make_request(:get, url + '/rates', @api_key, params)
-      self.refresh_from(response, @api_key, true)
+    return self
+  end
 
-      return self
+  def buy(params={})
+    if params.instance_of?(EasyPost::Rate)
+      temp = params.clone
+      params = {}
+      params[:rate] = temp
     end
 
-    def buy(params={})
-      if params.instance_of?(EasyPost::Rate)
-        temp = params.clone
-        params = {}
-        params[:rate] = temp
-      end
+    response = EasyPost.make_request(:post, url + '/buy', @api_key, params)
+    self.refresh_from(response, @api_key, true)
 
-      response = EasyPost.make_request(:post, url + '/buy', @api_key, params)
-      self.refresh_from(response, @api_key, true)
+    return self
+  end
 
-      return self
+  def insure(params={})
+    if params.is_a?(Integer) || params.is_a?(Float)
+      temp = params.clone
+      params = {}
+      params[:amount] = temp
     end
 
-    def insure(params={})
-      if params.is_a?(Integer) || params.is_a?(Float)
-        temp = params.clone
-        params = {}
-        params[:amount] = temp
-      end
+    response = EasyPost.make_request(:post, url + '/insure', @api_key, params)
+    self.refresh_from(response, @api_key, true)
 
-      response = EasyPost.make_request(:post, url + '/insure', @api_key, params)
-      self.refresh_from(response, @api_key, true)
+    return self
+  end
 
-      return self
+  def refund(params={})
+    response = EasyPost.make_request(:get, url + '/refund', @api_key, params)
+    self.refresh_from(response, @api_key, true)
+
+    return self
+  end
+
+  def print(params={})
+    if params.instance_of?(EasyPost::Printer)
+      return params.print(self.postage_label)
+    end
+    return false
+  end
+
+  def label(params={})
+    if params.is_a?(String)
+      temp = params.clone
+      params = {}
+      params[:file_format] = temp
     end
 
-    def refund(params={})
-      response = EasyPost.make_request(:get, url + '/refund', @api_key, params)
-      self.refresh_from(response, @api_key, true)
+    response = EasyPost.make_request(:get, url + '/label', @api_key, params)
+    self.refresh_from(response, @api_key, true)
 
-      return self
+    return self
+  end
+
+  def lowest_rate(carriers=[], services=[])
+    lowest = nil
+
+    self.get_rates unless self.rates
+
+    carriers = EasyPost::Util.normalize_string_list(carriers)
+
+    negative_carriers = []
+    carriers_copy = carriers.clone
+    carriers_copy.each do |carrier|
+      if carrier[0,1] == '!'
+        negative_carriers << carrier[1..-1]
+        carriers.delete(carrier)
+      end
     end
 
-    def print(params={})
-      if params.instance_of?(EasyPost::Printer)
-        return params.print(self.postage_label)
+    services = EasyPost::Util.normalize_string_list(services)
+
+    negative_services = []
+    services_copy = services.clone
+    services_copy.each do |service|
+      if service[0,1] == '!'
+        negative_services << service[1..-1]
+        services.delete(service)
       end
-      return false
     end
 
-    def label(params={})
-      if params.is_a?(String)
-        temp = params.clone
-        params = {}
-        params[:file_format] = temp
+    self.rates.each do |k|
+
+      rate_carrier = k.carrier.downcase
+      if carriers.size() > 0 && !carriers.include?(rate_carrier)
+        next
+      end
+      if negative_carriers.size() > 0 && negative_carriers.include?(rate_carrier)
+        next
       end
 
-      response = EasyPost.make_request(:get, url + '/label', @api_key, params)
-      self.refresh_from(response, @api_key, true)
+      rate_service = k.service.downcase
+      if services.size() > 0 && !services.include?(rate_service)
+        next
+      end
+      if negative_services.size() > 0 && negative_services.include?(rate_service)
+        next
+      end
 
-      return self
+      if lowest == nil || k.rate.to_f < lowest.rate.to_f
+          lowest = k
+      end
     end
 
-    def lowest_rate(carriers=[], services=[])
-      lowest = nil
+    raise EasyPost::Error.new('No rates found.') if lowest == nil
 
-      self.get_rates unless self.rates
-
-      carriers = EasyPost::Util.normalize_string_list(carriers)
-
-      negative_carriers = []
-      carriers_copy = carriers.clone
-      carriers_copy.each do |carrier|
-        if carrier[0,1] == '!'
-          negative_carriers << carrier[1..-1]
-          carriers.delete(carrier)
-        end
-      end
-
-      services = EasyPost::Util.normalize_string_list(services)
-
-      negative_services = []
-      services_copy = services.clone
-      services_copy.each do |service|
-        if service[0,1] == '!'
-          negative_services << service[1..-1]
-          services.delete(service)
-        end
-      end
-
-      self.rates.each do |k|
-
-        rate_carrier = k.carrier.downcase
-        if carriers.size() > 0 && !carriers.include?(rate_carrier)
-          next
-        end
-        if negative_carriers.size() > 0 && negative_carriers.include?(rate_carrier)
-          next
-        end
-
-        rate_service = k.service.downcase
-        if services.size() > 0 && !services.include?(rate_service)
-          next
-        end
-        if negative_services.size() > 0 && negative_services.include?(rate_service)
-          next
-        end
-
-        if lowest == nil || k.rate.to_f < lowest.rate.to_f
-            lowest = k
-        end
-      end
-
-      raise Error.new('No rates found.') if lowest == nil
-
-      return lowest
-    end
-
+    return lowest
   end
 end

--- a/lib/easypost/tracker.rb
+++ b/lib/easypost/tracker.rb
@@ -1,15 +1,13 @@
-module EasyPost
-  class Tracker < Resource
-    def self.create_list(params={}, api_key=nil)
-      url = self.url + '/create_list'
-      response = EasyPost.make_request(:post, url, api_key, params)
-      return true
-    end
+class EasyPost::Tracker < EasyPost::Resource
+  def self.create_list(params={}, api_key=nil)
+    url = self.url + '/create_list'
+    response = EasyPost.make_request(:post, url, api_key, params)
+    return true
+  end
 
-    def self.all_updated(params={}, api_key=nil)
-      url = self.url + '/all_updated'
-      response = EasyPost.make_request(:get, url, api_key, params)
-      return Util.convert_to_easypost_object(response, api_key)
-    end
+  def self.all_updated(params={}, api_key=nil)
+    url = self.url + '/all_updated'
+    response = EasyPost.make_request(:get, url, api_key, params)
+    return EasyPost::Util.convert_to_easypost_object(response, api_key)
   end
 end

--- a/lib/easypost/user.rb
+++ b/lib/easypost/user.rb
@@ -1,47 +1,45 @@
-module EasyPost
-  class User < Resource
-    def self.create(params={}, api_key=nil)
-      response = EasyPost.make_request(:post, self.url, api_key, {self.class_name.to_sym => params})
-      return Util.convert_to_easypost_object(response, api_key)
+class EasyPost::User < EasyPost::Resource
+  def self.create(params={}, api_key=nil)
+    response = EasyPost.make_request(:post, self.url, api_key, {self.class_name.to_sym => params})
+    return EasyPost::Util.convert_to_easypost_object(response, api_key)
+  end
+
+  def save
+    if @unsaved_values.length > 0
+      values = {}
+      @unsaved_values.each { |k| values[k] = @values[k] }
+
+      wrapped_params = {user: values}
+
+      response = EasyPost.make_request(:put, url, @api_key, wrapped_params)
+      refresh_from(response, api_key)
     end
+    return self
+  end
 
-    def save
-      if @unsaved_values.length > 0
-        values = {}
-        @unsaved_values.each { |k| values[k] = @values[k] }
+  def self.retrieve_me
+    self.all
+  end
 
-        wrapped_params = {user: values}
+  def self.all_api_keys
+    response = EasyPost.make_request(:get, "/api_keys", @api_key)
+    return EasyPost::Util.convert_to_easypost_object(response, api_key)
+  end
 
-        response = EasyPost.make_request(:put, url, @api_key, wrapped_params)
-        refresh_from(response, api_key)
-      end
-      return self
-    end
+  def api_keys
+    api_keys = EasyPost::User.all_api_keys
 
-    def self.retrieve_me
-      self.all
-    end
-
-    def self.all_api_keys
-      response = EasyPost.make_request(:get, "/api_keys", @api_key)
-      return Util.convert_to_easypost_object(response, api_key)
-    end
-
-    def api_keys
-      api_keys = EasyPost::User.all_api_keys
-
-      if api_keys.id == self.id
-        my_api_keys = api_keys.keys
-      else
-        for child in api_keys.children
-          if child.id == self.id
-            my_api_keys = child.keys
-            break
-          end
+    if api_keys.id == self.id
+      my_api_keys = api_keys.keys
+    else
+      for child in api_keys.children
+        if child.id == self.id
+          my_api_keys = child.keys
+          break
         end
       end
-
-      my_api_keys
     end
+
+    my_api_keys
   end
 end

--- a/lib/easypost/util.rb
+++ b/lib/easypost/util.rb
@@ -1,112 +1,110 @@
-module EasyPost
-  module Util
-    def self.objects_to_ids(obj)
-      case obj
-      when Resource
-        return {:id => obj.id}
-      when Hash
-        result = {}
-        obj.each { |k, v| result[k] = objects_to_ids(v) unless v.nil? }
-        return result
-      when Array
-        return obj.map { |v| objects_to_ids(v) }
-      else
-        return obj
-      end
+module EasyPost::Util
+  def self.objects_to_ids(obj)
+    case obj
+    when EasyPost::Resource
+      return {:id => obj.id}
+    when Hash
+      result = {}
+      obj.each { |k, v| result[k] = objects_to_ids(v) unless v.nil? }
+      return result
+    when Array
+      return obj.map { |v| objects_to_ids(v) }
+    else
+      return obj
     end
+  end
 
-    def self.normalize_string_list(lst)
-      lst = lst.is_a?(String) ? lst.split(',') : Array(lst)
-      lst.map(&:to_s).map(&:downcase).map(&:strip)
-    end
+  def self.normalize_string_list(lst)
+    lst = lst.is_a?(String) ? lst.split(',') : Array(lst)
+    lst.map(&:to_s).map(&:downcase).map(&:strip)
+  end
 
-    def self.convert_to_easypost_object(response, api_key, parent=nil, name=nil)
-      types = {
-        'Address' => Address,
-        'ScanForm' => ScanForm,
-        'CustomsItem' => CustomsItem,
-        'CustomsInfo' => CustomsInfo,
-        'Parcel' => Parcel,
-        'Shipment' => Shipment,
-        'Rate' => Rate,
-        'Refund' => Refund,
-        'Event' => Event,
-        'Batch' => Batch,
-        'Tracker' => Tracker,
-        'Item' => Item,
-        'Insurance' => Insurance,
-        'Order' => Order,
-        'Pickup' => Pickup,
-        'PickupRate' => PickupRate,
-        'PostageLabel' => PostageLabel,
-        'Printer' => Printer,
-        'PrintJob' => PrintJob,
-        'CarrierAccount' => CarrierAccount,
-        'User' => User,
-        'Report' => Report,
-        'ShipmentReport' => Report,
-        'PaymentLogReport' => Report,
-        'TrackerReport' => Report,
-        'RefundReport' => Report,
-        'ShipmentInvoiceReport' => Report,
-        'Webhook' => Webhook
-      }
+  def self.convert_to_easypost_object(response, api_key, parent=nil, name=nil)
+    types = {
+      'Address' => EasyPost::Address,
+      'ScanForm' => EasyPost::ScanForm,
+      'CustomsItem' => EasyPost::CustomsItem,
+      'CustomsInfo' => EasyPost::CustomsInfo,
+      'Parcel' => EasyPost::Parcel,
+      'Shipment' => EasyPost::Shipment,
+      'Rate' => EasyPost::Rate,
+      'Refund' => EasyPost::Refund,
+      'Event' => EasyPost::Event,
+      'Batch' => EasyPost::Batch,
+      'Tracker' => EasyPost::Tracker,
+      'Item' => EasyPost::Item,
+      'Insurance' => EasyPost::Insurance,
+      'Order' => EasyPost::Order,
+      'Pickup' => EasyPost::Pickup,
+      'PickupRate' => EasyPost::PickupRate,
+      'PostageLabel' => EasyPost::PostageLabel,
+      'Printer' => EasyPost::Printer,
+      'PrintJob' => EasyPost::PrintJob,
+      'CarrierAccount' => EasyPost::CarrierAccount,
+      'User' => EasyPost::User,
+      'Report' => EasyPost::Report,
+      'ShipmentReport' => EasyPost::Report,
+      'PaymentLogReport' => EasyPost::Report,
+      'TrackerReport' => EasyPost::Report,
+      'RefundReport' => EasyPost::Report,
+      'ShipmentInvoiceReport' => EasyPost::Report,
+      'Webhook' => EasyPost::Webhook
+    }
 
-      prefixes = {
-        'adr' => Address,
-        'sf' => ScanForm,
-        'cstitem' => CustomsItem,
-        'cstinfo' => CustomsInfo,
-        'prcl' => Parcel,
-        'shp' => Shipment,
-        'rate' => Rate,
-        'rfnd' => Refund,
-        'evt' => Event,
-        'batch' => Batch,
-        'trk' => Tracker,
-        'item' => Item,
-        'ins' => Insurance,
-        'order' => Order,
-        'pickup' => Pickup,
-        'pickuprate' => PickupRate,
-        'pl' => PostageLabel,
-        'printer' => Printer,
-        'printjob' => PrintJob,
-        'ca' => CarrierAccount,
-        'user' => User,
-        'shprep' => Report,
-        'plrep' => Report,
-        'trkrep' => Report,
-        'refrep' => Report,
-        'shpinvrep' => Report,
-        'hook' => Webhook
-      }
+    prefixes = {
+      'adr' => EasyPost::Address,
+      'sf' => EasyPost::ScanForm,
+      'cstitem' => EasyPost::CustomsItem,
+      'cstinfo' => EasyPost::CustomsInfo,
+      'prcl' => EasyPost::Parcel,
+      'shp' => EasyPost::Shipment,
+      'rate' => EasyPost::Rate,
+      'rfnd' => EasyPost::Refund,
+      'evt' => EasyPost::Event,
+      'batch' => EasyPost::Batch,
+      'trk' => EasyPost::Tracker,
+      'item' => EasyPost::Item,
+      'ins' => EasyPost::Insurance,
+      'order' => EasyPost::Order,
+      'pickup' => EasyPost::Pickup,
+      'pickuprate' => EasyPost::PickupRate,
+      'pl' => EasyPost::PostageLabel,
+      'printer' => EasyPost::Printer,
+      'printjob' => EasyPost::PrintJob,
+      'ca' => EasyPost::CarrierAccount,
+      'user' => EasyPost::User,
+      'shprep' => EasyPost::Report,
+      'plrep' => EasyPost::Report,
+      'trkrep' => EasyPost::Report,
+      'refrep' => EasyPost::Report,
+      'shpinvrep' => EasyPost::Report,
+      'hook' => EasyPost::Webhook
+    }
 
-      case response
-      when Array
-        return response.map { |i| convert_to_easypost_object(i, api_key, parent) }
-      when Hash
-        if cls_name = response[:object]
-          cls = types[cls_name]
-        elsif response[:id]
-          if response[:id].index('_').nil?
-            cls = EasyPostObject
-          elsif cls_prefix = response[:id][0..response[:id].index('_')]
-            cls = prefixes[cls_prefix[0..-2]]
-          end
-        elsif response['id']
-          if response['id'].index('_').nil?
-            cls = EasyPostObject
-          elsif cls_prefix = response['id'][0..response['id'].index('_')]
-            cls = prefixes[cls_prefix[0..-2]]
-          end
+    case response
+    when Array
+      return response.map { |i| convert_to_easypost_object(i, api_key, parent) }
+    when Hash
+      if cls_name = response[:object]
+        cls = types[cls_name]
+      elsif response[:id]
+        if response[:id].index('_').nil?
+          cls = EasyPost::EasyPostObject
+        elsif cls_prefix = response[:id][0..response[:id].index('_')]
+          cls = prefixes[cls_prefix[0..-2]]
         end
-
-        cls ||= EasyPostObject
-        return cls.construct_from(response, api_key, parent, name)
-      else
-        return response
+      elsif response['id']
+        if response['id'].index('_').nil?
+          cls = EasyPost::EasyPostObject
+        elsif cls_prefix = response['id'][0..response['id'].index('_')]
+          cls = prefixes[cls_prefix[0..-2]]
+        end
       end
+
+      cls ||= EasyPost::EasyPostObject
+      return cls.construct_from(response, api_key, parent, name)
+    else
+      return response
     end
   end
 end

--- a/lib/easypost/webhook.rb
+++ b/lib/easypost/webhook.rb
@@ -1,31 +1,29 @@
-module EasyPost
-  class Webhook < Resource
-    def update(params={})
-      # NOTE: This method is redefined here since the "url" method conflicts
-      # with the objects field
-      unless self.id
-        raise Error.new("Could not determine which URL to request: #{self.class} instance has invalid ID: #{self.id.inspect}")
-      end
-      instance_url = "#{self.class.url}/#{CGI.escape(id)}"
-
-      response = EasyPost.make_request(:put, instance_url, @api_key, params)
-      self.refresh_from(response, api_key, true)
-
-      return self
+class EasyPost::Webhook < EasyPost::Resource
+  def update(params={})
+    # NOTE: This method is redefined here since the "url" method conflicts
+    # with the objects field
+    unless self.id
+      raise EasyPost::Error.new("Could not determine which URL to request: #{self.class} instance has invalid ID: #{self.id.inspect}")
     end
+    instance_url = "#{self.class.url}/#{CGI.escape(id)}"
 
-    def delete
-      # NOTE: This method is redefined here since the "url" method conflicts
-      # with the objects field
-      unless self.id
-        raise Error.new("Could not determine which URL to request: #{self.class} instance has invalid ID: #{self.id.inspect}")
-      end
-      instance_url = "#{self.class.url}/#{CGI.escape(id)}"
+    response = EasyPost.make_request(:put, instance_url, @api_key, params)
+    self.refresh_from(response, api_key, true)
 
-      response = EasyPost.make_request(:delete, instance_url, @api_key)
-      refresh_from(response, api_key)
+    return self
+  end
 
-      return self
+  def delete
+    # NOTE: This method is redefined here since the "url" method conflicts
+    # with the objects field
+    unless self.id
+      raise EasyPost::Error.new("Could not determine which URL to request: #{self.class} instance has invalid ID: #{self.id.inspect}")
     end
+    instance_url = "#{self.class.url}/#{CGI.escape(id)}"
+
+    response = EasyPost.make_request(:delete, instance_url, @api_key)
+    refresh_from(response, api_key)
+
+    return self
   end
 end


### PR DESCRIPTION
I would eventually like to get Rubocop working on this repository, but basically every line fails Rubocop today.

This is the first change, which helps prevent a whole mess of confusion around relative-scoped modules and classes. It changes almost every line of the application. The only changes are making all of the class/module names collapsed, fixing indentation, and fixing the half-dozen places where we were calling classes relatively (e.g., changing `Error.new` into `EasyPost::Error.new`).