### PR TITLE
Look up EasyPostObject attributes by string key

### DIFF
--- a/lib/easypost/object.rb
+++ b/lib/easypost/object.rb
@@ -123,6 +123,7 @@ module EasyPost
     def add_accessors(keys)
       metaclass.instance_eval do
         keys.each do |k|
+          k = k.to_s
           next if @@immutable_values.include?(k)
           k_eq = :"#{k}="
           define_method(k) { @values[k] }
@@ -132,7 +133,7 @@ module EasyPost
 
             cur = self
             cur_parent = self.parent
-            param = {}
+
             while cur_parent
               if cur.name
                 cur_parent.unsaved_values.add(cur.name)

--- a/spec/object_spec.rb
+++ b/spec/object_spec.rb
@@ -629,6 +629,10 @@ describe EasyPost::EasyPostObject do
         expect(rate).to be_a EasyPost::Rate
         expect(rate['carrier_account_id']).to eq('ca_1234')
       end
+
+      it 'constructs the object and allows you to look up the value by method' do
+        expect(rate.carrier_account_id).to eq('ca_1234')
+      end
     end
   end
 


### PR DESCRIPTION
This ensures the accessors will return the correct value when constructing an `EasyPostObject` with a hash using symbols for the keys.

Example:

**Before**
```rb
addr = EasyPost::EasyPostObject.construct_from(zip: "90210")
addr.zip # => nil
```

**After**
```rb
addr = EasyPost::EasyPostObject.construct_from(zip: "90210")
addr.zip # => "90210"
```