### PR TITLE
Support pattern matching in Ruby 2.7+

### DIFF
--- a/lib/easypost/object.rb
+++ b/lib/easypost/object.rb
@@ -75,6 +75,10 @@ class EasyPost::EasyPostObject
     @values
   end
 
+  def deconstruct_keys(_keys)
+    @values.transform_keys(&:to_sym)
+  end
+
   def each(&blk)
     @values.each(&blk)
   end

--- a/spec/object_spec.rb
+++ b/spec/object_spec.rb
@@ -649,4 +649,27 @@ describe EasyPost::EasyPostObject do
       expect(described_class.construct_from({}).to_s).to eq "{}"
     end
   end
+
+  if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.7")
+    describe "#deconstruct_keys" do
+      it "should allow pattern matching" do
+       pattern_matching = <<-RUBY
+          subject = described_class.construct_from({
+            "type" => "rate_error",
+            "carrier" => "GSO",
+            "message" => "Failure: Ship date must be within 5 days in future from current date & exclude weekend/GLS service holiday."
+          })
+
+          case subject
+          in { type: "rate_error", carrier: /gso/i, message: /ship date/i }
+            true
+          else
+            false
+          end
+        RUBY
+
+        expect { instance_eval(pattern_matching) }.to_not raise_error
+      end
+    end
+  end
 end


### PR DESCRIPTION
This adds the `deconstruct_keys` method to the EasyPostObject class so that you can pattern match with the objects directly.

I'm using this to define logic for handling specific errors from carriers

```ruby
shipment.messages.each do |message|
  case message
  in { type: /rate_error/i, carrier: /gso/i, message: /ship date/i }
    # try a different ship date
  else
    # pattern matching is exhaustive, so we need an else case
  end
end
```

I tried to avoid symbolizing the keys, but I learned that pattern matching a hash requires symbol keys, so the `deconstruct_keys` implementation converts the keys to symbols.