### PR TITLE
add a spec for a successful addresses#create_and_verify call

### DIFF
--- a/spec/address_spec.rb
+++ b/spec/address_spec.rb
@@ -2,6 +2,15 @@ require 'spec_helper'
 
 describe EasyPost::Address do
   describe ".create_and_verify" do
+    context "for a valid address" do
+      it "should work correctly" do
+        address = EasyPost::Address.create_and_verify(ADDRESS[:california])
+        expect(address.street1).to eq "164 TOWNSEND ST UNIT 1"
+        expect(address.verifications.zip4.success).to be true
+        expect(address.verifications.delivery.success).to be true
+      end
+    end
+
     context "for a successful response without an address" do
       it "should raise an error" do
         expect(EasyPost).to receive(:make_request).and_return({})

--- a/spec/cassettes/address/EasyPost_Address_create_and_verify_for_a_valid_address_should_work_correctly.yml
+++ b/spec/cassettes/address/EasyPost_Address_create_and_verify_for_a_valid_address_should_work_correctly.yml
@@ -1,0 +1,64 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.easypost.com/v2/addresses/create_and_verify
+    body:
+      encoding: UTF-8
+      string: '{"address":{"company":"EasyPost","street1":"164 Townsend Street","street2":"Unit
+        1","city":"San Francisco","state":"CA","zip":"94107","phone":"415-123-4567"}}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - EasyPost/v2 RubyClient/3.1.4 Ruby/2.5.8-p224
+      Content-Type:
+      - application/json
+      Authorization: "<AUTHORIZATION>"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Ep-Request-Uuid:
+      - c64376c05fda9434fb322302000b3f81
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, private
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Location:
+      - "/api/v2/addresses/adr_7ff37e3af0b648e985a33304fb94596e"
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Runtime:
+      - '0.048802'
+      Transfer-Encoding:
+      - chunked
+      X-Node:
+      - bigweb2nuq
+      X-Version-Label:
+      - easypost-202012162108-db09a3fa8d-master
+      X-Backend:
+      - easypost
+      X-Proxied:
+      - extlb1nuq 0872841421
+      - intlb2nuq 1d932d9f73
+      Strict-Transport-Security:
+      - max-age=15768000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: '{"address":{"id":"adr_7ff37e3af0b648e985a33304fb94596e","object":"Address","created_at":"2020-12-16T23:11:48+00:00","updated_at":"2020-12-16T23:11:48+00:00","name":null,"company":"EASYPOST","street1":"164
+        TOWNSEND ST UNIT 1","street2":"","city":"SAN FRANCISCO","state":"CA","zip":"94107-1990","country":"US","phone":"4151234567","email":null,"mode":"test","carrier_facility":null,"residential":false,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.78013,"longitude":-122.39112,"time_zone":"America/Los_Angeles"}}}}}'
+    http_version: null
+  recorded_at: Wed, 16 Dec 2020 23:11:48 GMT
+recorded_with: VCR 5.1.0


### PR DESCRIPTION
The `create_and_verify` function has been broken since 8c1dbd09a45bc12d93ee520ccd81e7f3b5f66432 (version 3.1.0). We had no tests for the happy case.

The underlying bug was fixed in #108; this adds a test to hopefully eliminate future breaking.