### PR TITLE
remove 2015-vintage experimental "all_updated" action on trackers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 * Removed deprecated `Item` object
 * Sorted EasyPost Resources list
+* Remove 2015-vintage experimental `all_updated` method on Tracker
 
 
 ## 3.3.0 2021-06-10

--- a/lib/easypost/tracker.rb
+++ b/lib/easypost/tracker.rb
@@ -4,10 +4,4 @@ class EasyPost::Tracker < EasyPost::Resource
     response = EasyPost.make_request(:post, url, api_key, params)
     return true
   end
-
-  def self.all_updated(params={}, api_key=nil)
-    url = self.url + '/all_updated'
-    response = EasyPost.make_request(:get, url, api_key, params)
-    return EasyPost::Util.convert_to_easypost_object(response, api_key)
-  end
 end


### PR DESCRIPTION
This endpoint was introduced as an experiment in 2015 and never documented. It has no users and is being removed.