### PR TITLE
feat: adds TaxIdentifier object

### DIFF
--- a/lib/easypost.rb
+++ b/lib/easypost.rb
@@ -121,7 +121,6 @@ module EasyPost
     request = Net::HTTP.const_get(method.capitalize).new(path)
     if body
       request.body = JSON.dump(EasyPost::Util.objects_to_ids(body))
-      puts request.body
     end
 
     request["Content-Type"] = "application/json"

--- a/lib/easypost.rb
+++ b/lib/easypost.rb
@@ -30,6 +30,7 @@ require "easypost/refund"
 require "easypost/report"
 require "easypost/scan_form"
 require "easypost/shipment"
+require "easypost/tax_identifier"
 require "easypost/tracker"
 require "easypost/user"
 require "easypost/webhook"
@@ -120,6 +121,7 @@ module EasyPost
     request = Net::HTTP.const_get(method.capitalize).new(path)
     if body
       request.body = JSON.dump(EasyPost::Util.objects_to_ids(body))
+      puts request.body
     end
 
     request["Content-Type"] = "application/json"

--- a/lib/easypost/tax_identifier.rb
+++ b/lib/easypost/tax_identifier.rb
@@ -1,0 +1,2 @@
+class EasyPost::TaxIdentifier < EasyPost::Resource
+end

--- a/lib/easypost/util.rb
+++ b/lib/easypost/util.rb
@@ -42,6 +42,7 @@ module EasyPost::Util
       'Report' => EasyPost::Report,
       'ScanForm' => EasyPost::ScanForm,
       'Shipment' => EasyPost::Shipment,
+      'TaxIdentifier' => EasyPost::TaxIdentifier,
       'ShipmentInvoiceReport' => EasyPost::Report,
       'ShipmentReport' => EasyPost::Report,
       'Tracker' => EasyPost::Tracker,


### PR DESCRIPTION
Adds the new `TaxIdentifier` object, although technically not needed to start using the TaxIdentifer object, good to add anyway.

An example of using this is simply passing the following on a shipment create call:

```ruby
tax_identifiers: [
  {
    entity: 'RECEIVER',
    tax_id_type: 'IOSS',
    tax_id: '12345',          
    issuing_country: 'GB',
  },
]
```