### PR TITLE
chore: replace API key in spec_helper with env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Up-to-date documentation at: https://easypost.com/docs
 
 ```bash
 # Run tests
-bundle exec rspec
+API_KEY=123... bundle exec rspec
 ```
 
 ## Releasing

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,7 +5,7 @@ Dir["./spec/support/**/*.rb"].each { |f| require f }
 
 RSpec.configure do |config|
   config.before(:each) do
-    EasyPost.api_key = 'BmvaWhg8mP26QXWdTplYWA'
+    EasyPost.api_key = ENV['API_KEY']
   end
 
   config.around(:each) do |example|


### PR DESCRIPTION
Replaces the hardcoded API key in `spec_helper` with `ENV` to retrieve the API_KEY env variable. (eg: `API_KEY=123 bundle exec rspec`)

We have this pattern in other client libraries.