### PR TITLE
chore: remove stamp_and_barcode_by_reference method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 * Bumps minimum Ruby version from `2.2` to `2.5`
 * Introduces `Rubocop` and lints the entire project
+* Removes deprecated and unusable `stamp_and_barcode_by_reference` method on the Batch object
 
 
 ## 3.5.0 2021-12-06

--- a/lib/easypost/batch.rb
+++ b/lib/easypost/batch.rb
@@ -37,10 +37,6 @@ class EasyPost::Batch < EasyPost::Resource
     self
   end
 
-  def stamp_and_barcode_by_reference(params = {})
-    EasyPost.make_request(:get, "#{url}/stamp_and_barcode_by_reference", @api_key, params)
-  end
-
   def create_scan_form(params = {})
     EasyPost.make_request(:post, "#{url}/scan_form", @api_key, params)
   end


### PR DESCRIPTION
Removes the unusable and deprecated `stamp_and_barcode_by_reference` method from the Batch object.