### PR TITLE
chore: remove the Shipment.get_rates function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 * Bumps minimum Ruby version from `2.2` to `2.5`
 * Introduces `Rubocop` and lints the entire project
 * Removes deprecated and unusable `stamp_and_barcode_by_reference` method on the Batch object
+* Explicitly returns an error of "not implemented" for `Rate.all` and `Parcel.all`
+* Removes the `Shipment.get_rates` function as shipments already contain rates. If you need to get new rates for a shipment, use the `Shipment.regenerate_rates` function instead
 
 
 ## 3.5.0 2021-12-06

--- a/lib/easypost/parcel.rb
+++ b/lib/easypost/parcel.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
 
 class EasyPost::Parcel < EasyPost::Resource
+  def self.all(_filters = {}, _api_key = nil)
+    raise NotImplementedError.new('Parcel.all not implemented.')
+  end
 end

--- a/lib/easypost/rate.rb
+++ b/lib/easypost/rate.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
 
 class EasyPost::Rate < EasyPost::Resource
+  def self.all(_filters = {}, _api_key = nil)
+    raise NotImplementedError.new('Rate.all not implemented.')
+  end
 end

--- a/lib/easypost/shipment.rb
+++ b/lib/easypost/shipment.rb
@@ -1,13 +1,6 @@
 # frozen_string_literal: true
 
 class EasyPost::Shipment < EasyPost::Resource
-  def get_rates(params = {})
-    response = EasyPost.make_request(:get, "#{url}/rates", @api_key, params)
-    refresh_from(response, @api_key, true)
-
-    self
-  end
-
   def regenerate_rates(params = {})
     response = EasyPost.make_request(:post, "#{url}/rerate", @api_key, params)
     refresh_from(response, @api_key, true)


### PR DESCRIPTION
* Explicitly returns an error of "not implemented" for `Rate.all` and `Parcel.all`
* Removes the `Shipment.get_rates` function as shipments already contain rates. If you need to get new rates for a shipment, use the `Shipment.regenerate_rates` function instead

I did these together as they are all breaking changes and needed prior to our next release.