### PR TITLE
feat: Resource.each enumerates resources across pages

### DIFF
--- a/lib/easypost/resource.rb
+++ b/lib/easypost/resource.rb
@@ -2,6 +2,8 @@
 
 # The Resource object is extended by each EasyPost object.
 class EasyPost::Resource < EasyPost::EasyPostObject
+  extend Enumerable
+
   # The class name of an EasyPost object.
   def self.class_name
     camel = name.split('::')[-1]
@@ -44,6 +46,18 @@ class EasyPost::Resource < EasyPost::EasyPostObject
   def self.all(filters = {}, api_key = nil)
     response = EasyPost.make_request(:get, url, api_key, filters)
     EasyPost::Util.convert_to_easypost_object(response, api_key)
+  end
+
+  def self.each(filters = {}, api_key = EasyPost.api_key, &block)
+    return to_enum(:each, filters, api_key) unless block_given?
+
+    loop do
+      page, has_more = all(filters, api_key).values
+      last = page.each(&block).last
+      break if page.empty? || !has_more
+
+      filters[:before_id] = last.id
+    end
   end
 
   # Retrieve an EasyPost object.


### PR DESCRIPTION
The big misnomer is `.all` which doesn't list ALL resources, it just lists one page.

By turning every resource into an `Enumerable` extension you now do very healthy, memory conscious iterator patterns with stdlib.

For instance:

```ruby
# find the first two most recent addresses in Maie
EasyPost::Address.lazy.select { |address| address.state == "ME" }.take(2)

# how many of the most recent 100 addresses have gone to which countries
EasyPost::Address.lazy.take(100).map(&:country).tally
```