### PR TITLE
chore: add shipment ID test

### DIFF
--- a/spec/cassettes/shipment/EasyPost_Shipment_create_creates_a_shipment_when_only_IDs_are_used.yml
+++ b/spec/cassettes/shipment/EasyPost_Shipment_create_creates_a_shipment_when_only_IDs_are_used.yml
@@ -1,0 +1,291 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.easypost.com/v2/addresses
+    body:
+      encoding: UTF-8
+      string: '{"address":{"name":"Jack Sparrow","company":"EasyPost","street1":"388
+        Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","phone":"5555555555"}}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - EasyPost/v2 RubyClient/4.1.0 Ruby/3.1.0-p0
+      Content-Type:
+      - application/json
+      Authorization: "<AUTHORIZATION>"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      X-Ep-Request-Uuid:
+      - 98b46e45622ba3aae78850df002e651e
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Location:
+      - "/api/v2/addresses/adr_e866b275a17111ec9c99ac1f6bc72124"
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"28cdcceec7278600b00e595996bd4cbe"
+      X-Request-Id:
+      - ceade837-6a2c-4f15-9ab9-26094a489d3a
+      X-Runtime:
+      - '0.034100'
+      Transfer-Encoding:
+      - chunked
+      X-Node:
+      - bigweb2nuq
+      X-Version-Label:
+      - easypost-202203111758-47abb850c9-master
+      X-Backend:
+      - easypost
+      X-Proxied:
+      - extlb1nuq 88c34981dc
+      - intlb1nuq 88c34981dc
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"adr_e866b275a17111ec9c99ac1f6bc72124","object":"Address","created_at":"2022-03-11T19:31:54+00:00","updated_at":"2022-03-11T19:31:54+00:00","name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}}'
+  recorded_at: Fri, 11 Mar 2022 19:31:54 GMT
+- request:
+    method: post
+    uri: https://api.easypost.com/v2/addresses
+    body:
+      encoding: UTF-8
+      string: '{"address":{"name":"Jack Sparrow","company":"EasyPost","street1":"388
+        Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","phone":"5555555555"}}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - EasyPost/v2 RubyClient/4.1.0 Ruby/3.1.0-p0
+      Content-Type:
+      - application/json
+      Authorization: "<AUTHORIZATION>"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      X-Ep-Request-Uuid:
+      - 98b46e43622ba3aae78850e0002e6532
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Location:
+      - "/api/v2/addresses/adr_e8875cc7a17111ec9ca1ac1f6bc72124"
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"408a25a3a69054cffca0dcbf43d6746c"
+      X-Request-Id:
+      - ad30dc02-2efc-477a-a3e5-bce3ce715c38
+      X-Runtime:
+      - '0.035249'
+      Transfer-Encoding:
+      - chunked
+      X-Node:
+      - bigweb2nuq
+      X-Version-Label:
+      - easypost-202203111758-47abb850c9-master
+      X-Backend:
+      - easypost
+      X-Proxied:
+      - extlb1nuq 88c34981dc
+      - intlb1nuq 88c34981dc
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"adr_e8875cc7a17111ec9ca1ac1f6bc72124","object":"Address","created_at":"2022-03-11T19:31:54+00:00","updated_at":"2022-03-11T19:31:54+00:00","name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}}'
+  recorded_at: Fri, 11 Mar 2022 19:31:54 GMT
+- request:
+    method: post
+    uri: https://api.easypost.com/v2/parcels
+    body:
+      encoding: UTF-8
+      string: '{"parcel":{"length":"10","width":"8","height":"4","weight":"15.4"}}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - EasyPost/v2 RubyClient/4.1.0 Ruby/3.1.0-p0
+      Content-Type:
+      - application/json
+      Authorization: "<AUTHORIZATION>"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      X-Ep-Request-Uuid:
+      - 98b46e46622ba3aae78850e1002e6554
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Location:
+      - "/api/v2/parcels.prcl_531a9468b03840f9a4cd8a8a7b9b7a19"
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"a150c3ae154ac9ba14e69b4aed34f2f7"
+      X-Request-Id:
+      - 12e0c22d-e394-42f3-ab6c-50e99c8f8a68
+      X-Runtime:
+      - '0.026910'
+      Transfer-Encoding:
+      - chunked
+      X-Node:
+      - bigweb7nuq
+      X-Version-Label:
+      - easypost-202203111758-47abb850c9-master
+      X-Backend:
+      - easypost
+      X-Canary:
+      - direct
+      X-Proxied:
+      - extlb1nuq 88c34981dc
+      - intlb1nuq 88c34981dc
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"prcl_531a9468b03840f9a4cd8a8a7b9b7a19","object":"Parcel","created_at":"2022-03-11T19:31:54Z","updated_at":"2022-03-11T19:31:54Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"}'
+  recorded_at: Fri, 11 Mar 2022 19:31:54 GMT
+- request:
+    method: post
+    uri: https://api.easypost.com/v2/shipments
+    body:
+      encoding: UTF-8
+      string: '{"shipment":{"from_address":{"id":"adr_e866b275a17111ec9c99ac1f6bc72124"},"to_address":{"id":"adr_e8875cc7a17111ec9ca1ac1f6bc72124"},"parcel":{"id":"prcl_531a9468b03840f9a4cd8a8a7b9b7a19"}}}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - EasyPost/v2 RubyClient/4.1.0 Ruby/3.1.0-p0
+      Content-Type:
+      - application/json
+      Authorization: "<AUTHORIZATION>"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      X-Ep-Request-Uuid:
+      - 98b46e49622ba3abe78850e2002e6566
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Location:
+      - "/api/v2/shipments/shp_ff591ac4800d48bb9a9f6e58b0c962fc"
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"5f55d15b03f36ab37db4526f2b872fcb"
+      X-Request-Id:
+      - 4e671483-fbae-41e3-beaf-8c4b202f276d
+      X-Runtime:
+      - '0.204979'
+      Transfer-Encoding:
+      - chunked
+      X-Node:
+      - bigweb4nuq
+      X-Version-Label:
+      - easypost-202203111758-47abb850c9-master
+      X-Backend:
+      - easypost
+      X-Proxied:
+      - extlb1nuq 88c34981dc
+      - intlb1nuq 88c34981dc
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: '{"created_at":"2022-03-11T19:31:55Z","is_return":false,"messages":[],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":null,"updated_at":"2022-03-11T19:31:55Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_e866b275a17111ec9c99ac1f6bc72124","object":"Address","created_at":"2022-03-11T19:31:54+00:00","updated_at":"2022-03-11T19:31:54+00:00","name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_531a9468b03840f9a4cd8a8a7b9b7a19","object":"Parcel","created_at":"2022-03-11T19:31:54Z","updated_at":"2022-03-11T19:31:54Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":null,"rates":[{"id":"rate_cfca325e957c4ae19aebc39c9a882107","object":"Rate","created_at":"2022-03-11T19:31:55Z","updated_at":"2022-03-11T19:31:55Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_ff591ac4800d48bb9a9f6e58b0c962fc","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},{"id":"rate_f8d2016ff8f64fa6ba2e629b9b8c51d0","object":"Rate","created_at":"2022-03-11T19:31:55Z","updated_at":"2022-03-11T19:31:55Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_ff591ac4800d48bb9a9f6e58b0c962fc","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},{"id":"rate_c32a4f3092a04281a2875f756bebb4be","object":"Rate","created_at":"2022-03-11T19:31:55Z","updated_at":"2022-03-11T19:31:55Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_ff591ac4800d48bb9a9f6e58b0c962fc","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},{"id":"rate_ea7f810277cb4b5cb72df3f5d72b056f","object":"Rate","created_at":"2022-03-11T19:31:55Z","updated_at":"2022-03-11T19:31:55Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_ff591ac4800d48bb9a9f6e58b0c962fc","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"}],"refund_status":null,"scan_form":null,"selected_rate":null,"tracker":null,"to_address":{"id":"adr_e8875cc7a17111ec9ca1ac1f6bc72124","object":"Address","created_at":"2022-03-11T19:31:54+00:00","updated_at":"2022-03-11T19:31:54+00:00","name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"usps_zone":1,"return_address":{"id":"adr_e866b275a17111ec9c99ac1f6bc72124","object":"Address","created_at":"2022-03-11T19:31:54+00:00","updated_at":"2022-03-11T19:31:54+00:00","name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_e8875cc7a17111ec9ca1ac1f6bc72124","object":"Address","created_at":"2022-03-11T19:31:54+00:00","updated_at":"2022-03-11T19:31:54+00:00","name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"forms":[],"fees":[],"id":"shp_ff591ac4800d48bb9a9f6e58b0c962fc","object":"Shipment"}'
+  recorded_at: Fri, 11 Mar 2022 19:31:55 GMT
+recorded_with: VCR 6.0.0

--- a/spec/shipment_spec.rb
+++ b/spec/shipment_spec.rb
@@ -41,6 +41,27 @@ describe EasyPost::Shipment do
       expect(shipment.id).to match('shp_')
       expect(shipment.tax_identifiers[0].tax_id_type).to eq('IOSS')
     end
+
+    it 'creates a shipment when only IDs are used' do
+      from_address = EasyPost::Address.create(Fixture.basic_address)
+      to_address = EasyPost::Address.create(Fixture.basic_address)
+      parcel = EasyPost::Parcel.create(Fixture.basic_parcel)
+
+      shipment = described_class.create(
+        {
+          from_address: { id: from_address.id },
+          to_address: { id: to_address.id },
+          parcel: { id: parcel.id },
+        },
+      )
+
+      expect(shipment).to be_an_instance_of(described_class)
+      expect(shipment.id).to match('shp_')
+      expect(shipment.from_address.id).to match('adr_')
+      expect(shipment.to_address.id).to match('adr_')
+      expect(shipment.parcel.id).to match('prcl_')
+      expect(shipment.from_address.street1).to eq('388 Townsend St')
+    end
   end
 
   describe '.retrieve' do


### PR DESCRIPTION
Adds a test when only IDs are passed to object creation. This was brought up as a way to check behavior across all libs due to: https://github.com/EasyPost/easypost-node/issues/222