### PR TITLE
make it easier to toggle thread safety: 149

### DIFF
--- a/lib/easypost.rb
+++ b/lib/easypost.rb
@@ -42,7 +42,7 @@ module EasyPost
   DEFAULT_USER_AGENT = "EasyPost/v2 RubyClient/#{EasyPost::VERSION} Ruby/#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}"
 
   class << self
-    attr_accessor :api_key, :api_base
+    attr_accessor :api_key, :api_base, :use_threaded_connection
     attr_writer :default_connection
   end
 
@@ -56,10 +56,17 @@ module EasyPost
   end
 
   def self.default_connection
-    @default_connection ||= EasyPost::Connection.new(
-      uri: URI(api_base),
-      config: http_config,
-    )
+    if use_threaded_connection
+      EasyPost::Connection.new(
+        uri: URI(api_base),
+        config: http_config,
+        )
+    else
+      @default_connection ||= EasyPost::Connection.new(
+        uri: URI(api_base),
+        config: http_config,
+        )
+    end
   end
 
   def self.authorization(key)


### PR DESCRIPTION
while you can technically replace a default connection with a performant thread safe connection, that dependency doesnt feel great because it means i need to maintain a test of easypost that the interface doesnt change of the custom connection object i made. in an attempt to satisfy the benefit of those who are being single threaded, but give multi-folks a way to not get bottlenecked by deafult, thoughts on something like this?

reflecting a similar sentiment as https://github.com/EasyPost/easypost-ruby/pull/149#issuecomment-1068048850