### PR TITLE
[feat] Support for `columns` and `additional_columns` on Report creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## Next release
+* Add support for `columns` and `additional_columns` on Report creation
+
 ## v4.1.2 (2022-03-16)
 
 - Rolls back the original connection behavior of establishing a new connection for every request (restores previous expectations for multithreaded implementations)

--- a/lib/easypost/object.rb
+++ b/lib/easypost/object.rb
@@ -134,7 +134,9 @@ class EasyPost::EasyPostObject
 
   # The metaclass of an object.
   def metaclass
-    class << self; self; end
+    class << self
+      self;
+    end
   end
 
   # Add accessors of an object.

--- a/lib/easypost/object.rb
+++ b/lib/easypost/object.rb
@@ -134,9 +134,7 @@ class EasyPost::EasyPostObject
 
   # The metaclass of an object.
   def metaclass
-    class << self
-      self;
-    end
+    class << self; self; end
   end
 
   # Add accessors of an object.

--- a/lib/easypost/report.rb
+++ b/lib/easypost/report.rb
@@ -5,6 +5,21 @@ class EasyPost::Report < EasyPost::Resource
   # Create a Report.
   def self.create(params = {}, api_key = nil)
     url = "#{self.url}/#{params[:type]}"
+
+    columns = params[:columns] || []
+    additional_columns = params[:additional_columns] || []
+
+    url += '?'
+    columns.each do |column|
+      url += "columns[]=#{column}&"
+    end
+    additional_columns.each do |additional_column|
+      url += "additional_columns[]=#{additional_column}&"
+    end
+
+    # remove params already included in the query string
+    params = params.reject { |k, _| [:columns, :additional_columns].include?(k) }
+
     wrapped_params = {}
     wrapped_params[class_name.to_sym] = params
 

--- a/spec/cassettes/report/EasyPost_Report_create_creates_a_report_with_custom_additional_columns.yml
+++ b/spec/cassettes/report/EasyPost_Report_create_creates_a_report_with_custom_additional_columns.yml
@@ -1,0 +1,68 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.easypost.com/v2/reports/shipment?additional_columns%5B%5D=from_company&additional_columns%5B%5D=from_name
+    body:
+      encoding: UTF-8
+      string: '{"start_date":"2022-02-21","end_date":"2022-02-23","type":"shipment"}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - EasyPost/v2 RubyClient/4.1.2 Ruby/3.0.3-p157
+      Content-Type:
+      - application/json
+      Authorization: "<AUTHORIZATION>"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      X-Ep-Request-Uuid:
+      - 6628d8c56238effef1fda3bd003e25aa
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"43449e77576a44228520bb6007460884"
+      X-Runtime:
+      - '0.040208'
+      Transfer-Encoding:
+      - chunked
+      X-Node:
+      - bigweb1nuq
+      X-Version-Label:
+      - easypost-202203182244-fb6aae87d1-master
+      X-Backend:
+      - easypost
+      X-Proxied:
+      - extlb3wdc 3e97db20d4
+      - intlb1wdc 3e97db20d4
+      - intlb2nuq 3e97db20d4
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"shprep_11e9ac08c99d4805926cd0d77262d19d","object":"ShipmentReport","created_at":"2022-03-21T21:37:03Z","updated_at":"2022-03-21T21:37:03Z","start_date":"2022-02-21","end_date":"2022-02-23","mode":"test","status":"new","url":null,"url_expires_at":null,"include_children":false}'
+  recorded_at: Mon, 21 Mar 2022 21:37:03 GMT
+recorded_with: VCR 6.0.0

--- a/spec/cassettes/report/EasyPost_Report_create_creates_a_report_with_custom_columns.yml
+++ b/spec/cassettes/report/EasyPost_Report_create_creates_a_report_with_custom_columns.yml
@@ -1,0 +1,67 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.easypost.com/v2/reports/shipment?columns%5B%5D=usps_zone
+    body:
+      encoding: UTF-8
+      string: '{"start_date":"2022-02-21","end_date":"2022-02-23","type":"shipment"}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - EasyPost/v2 RubyClient/4.1.2 Ruby/3.0.3-p157
+      Content-Type:
+      - application/json
+      Authorization: "<AUTHORIZATION>"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      X-Ep-Request-Uuid:
+      - 95d38f206238f013f1eb765900429d16
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"62866dc40f21442dfc971ad3b92d8859"
+      X-Runtime:
+      - '0.037620'
+      Transfer-Encoding:
+      - chunked
+      X-Node:
+      - bigweb8nuq
+      X-Version-Label:
+      - easypost-202203182244-fb6aae87d1-master
+      X-Backend:
+      - easypost
+      X-Proxied:
+      - extlb2nuq 3e97db20d4
+      - intlb1nuq 3e97db20d4
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"shprep_1b2712c54fa34a4a892e96c38c6088af","object":"ShipmentReport","created_at":"2022-03-21T21:37:23Z","updated_at":"2022-03-21T21:37:23Z","start_date":"2022-02-21","end_date":"2022-02-23","mode":"test","status":"new","url":null,"url_expires_at":null,"include_children":false}'
+  recorded_at: Mon, 21 Mar 2022 21:37:23 GMT
+recorded_with: VCR 6.0.0

--- a/spec/report_spec.rb
+++ b/spec/report_spec.rb
@@ -67,9 +67,9 @@ describe EasyPost::Report do
         columns: ['usps_zone'],
       )
 
-      expect(report).to be_an_instance_of(described_class)
       # verify params by checking URL in cassette
       # can't do any more verification without downloading CSV
+      expect(report).to be_an_instance_of(described_class)
     end
 
     it 'creates a report with custom additional columns' do
@@ -80,9 +80,9 @@ describe EasyPost::Report do
         additional_columns: %w[from_name from_company],
       )
 
-      expect(report).to be_an_instance_of(described_class)
       # verify params by checking URL in cassette
       # can't do any more verification without downloading CSV
+      expect(report).to be_an_instance_of(described_class)
     end
   end
 

--- a/spec/report_spec.rb
+++ b/spec/report_spec.rb
@@ -58,6 +58,33 @@ describe EasyPost::Report do
       expect(report).to be_an_instance_of(described_class)
       expect(report.id).to match('trkrep')
     end
+
+    it 'creates a report with custom columns' do
+      report = described_class.create(
+        start_date: Fixture.report_start_date,
+        end_date: Fixture.report_end_date,
+        type: 'shipment',
+        columns: ['usps_zone'],
+      )
+
+      expect(report).to be_an_instance_of(described_class)
+      # verify params by checking URL in cassette
+      # can't do any more verification without downloading CSV
+    end
+
+    it 'creates a report with custom additional columns' do
+      report = described_class.create(
+        start_date: Fixture.report_start_date,
+        end_date: Fixture.report_end_date,
+        type: 'shipment',
+        additional_columns: %w[from_name from_company],
+      )
+
+      expect(report).to be_an_instance_of(described_class)
+      # verify params by checking URL in cassette
+      # can't do any more verification without downloading CSV
+    end
+
   end
 
   describe '.retrieve' do

--- a/spec/report_spec.rb
+++ b/spec/report_spec.rb
@@ -84,7 +84,6 @@ describe EasyPost::Report do
       # verify params by checking URL in cassette
       # can't do any more verification without downloading CSV
     end
-
   end
 
   describe '.retrieve' do


### PR DESCRIPTION
Based on https://github.com/EasyPost/easypost-csharp/pull/234

This PR:
- Adds support for specifying `columns` and `additional_columns` (both lists of strings) in the `parameters` dictionary passed into `EasyPost::Report.create(parameters)`
- Adds unit tests for this feature

Unfortunately, since the API response does not indicate the columns used for a report, the only way to ensure the report actually includes the columns requested would be to make a live API call, download the generated CSV report and parse its column headers. That is a complex unit test with many points of failure and prevents us from using VCR.

Instead, we simply assume that if no error is thrown during the API call to generate and retrieve the report, that the report contains the correct columns. If it doesn't, that constitutes a server-side error that is out of our control.