### PR TITLE
Report `columns` and `additional_columns` sent via body rather than query

### DIFF
--- a/lib/easypost/report.rb
+++ b/lib/easypost/report.rb
@@ -6,20 +6,6 @@ class EasyPost::Report < EasyPost::Resource
   def self.create(params = {}, api_key = nil)
     url = "#{self.url}/#{params[:type]}"
 
-    columns = params[:columns] || []
-    additional_columns = params[:additional_columns] || []
-
-    url += '?'
-    columns.each do |column|
-      url += "columns[]=#{column}&"
-    end
-    additional_columns.each do |additional_column|
-      url += "additional_columns[]=#{additional_column}&"
-    end
-
-    # remove params already included in the query string
-    params = params.reject { |k, _| [:columns, :additional_columns].include?(k) }
-
     wrapped_params = {}
     wrapped_params[class_name.to_sym] = params
 

--- a/spec/cassettes/report/EasyPost_Report_create_creates_a_report_with_custom_additional_columns.yml
+++ b/spec/cassettes/report/EasyPost_Report_create_creates_a_report_with_custom_additional_columns.yml
@@ -2,10 +2,10 @@
 http_interactions:
 - request:
     method: post
-    uri: https://api.easypost.com/v2/reports/shipment?additional_columns%5B%5D=from_company&additional_columns%5B%5D=from_name
+    uri: https://api.easypost.com/v2/reports/shipment
     body:
       encoding: UTF-8
-      string: '{"start_date":"2022-02-21","end_date":"2022-02-23","type":"shipment"}'
+      string: '{"start_date":"2022-02-21","end_date":"2022-02-23","type":"shipment","additional_columns":["from_name","from_company"]}'
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -34,7 +34,7 @@ http_interactions:
       Referrer-Policy:
       - strict-origin-when-cross-origin
       X-Ep-Request-Uuid:
-      - 6628d8c56238effef1fda3bd003e25aa
+      - 4aee9dd3623b9900f1fec14a00106e89
       Cache-Control:
       - no-cache, no-store
       Pragma:
@@ -44,25 +44,24 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"43449e77576a44228520bb6007460884"
+      - W/"28cb1b7850c7e763cafacdeecee45ca5"
       X-Runtime:
-      - '0.040208'
+      - '0.035080'
       Transfer-Encoding:
       - chunked
       X-Node:
-      - bigweb1nuq
+      - bigweb6nuq
       X-Version-Label:
-      - easypost-202203182244-fb6aae87d1-master
+      - easypost-202203231943-61a988cd70-master
       X-Backend:
       - easypost
       X-Proxied:
-      - extlb3wdc 3e97db20d4
-      - intlb1wdc 3e97db20d4
-      - intlb2nuq 3e97db20d4
+      - extlb1nuq 3e97db20d4
+      - intlb1nuq 3e97db20d4
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"shprep_11e9ac08c99d4805926cd0d77262d19d","object":"ShipmentReport","created_at":"2022-03-21T21:37:03Z","updated_at":"2022-03-21T21:37:03Z","start_date":"2022-02-21","end_date":"2022-02-23","mode":"test","status":"new","url":null,"url_expires_at":null,"include_children":false}'
-  recorded_at: Mon, 21 Mar 2022 21:37:03 GMT
+      string: '{"id":"shprep_ef43c376d8554c69876c09800d13492c","object":"ShipmentReport","created_at":"2022-03-23T22:02:40Z","updated_at":"2022-03-23T22:02:40Z","start_date":"2022-02-21","end_date":"2022-02-23","mode":"test","status":"new","url":null,"url_expires_at":null,"include_children":false}'
+  recorded_at: Wed, 23 Mar 2022 22:02:40 GMT
 recorded_with: VCR 6.0.0

--- a/spec/cassettes/report/EasyPost_Report_create_creates_a_report_with_custom_columns.yml
+++ b/spec/cassettes/report/EasyPost_Report_create_creates_a_report_with_custom_columns.yml
@@ -2,10 +2,10 @@
 http_interactions:
 - request:
     method: post
-    uri: https://api.easypost.com/v2/reports/shipment?columns%5B%5D=usps_zone
+    uri: https://api.easypost.com/v2/reports/shipment
     body:
       encoding: UTF-8
-      string: '{"start_date":"2022-02-21","end_date":"2022-02-23","type":"shipment"}'
+      string: '{"start_date":"2022-02-21","end_date":"2022-02-23","type":"shipment","columns":["usps_zone"]}'
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -34,7 +34,7 @@ http_interactions:
       Referrer-Policy:
       - strict-origin-when-cross-origin
       X-Ep-Request-Uuid:
-      - 95d38f206238f013f1eb765900429d16
+      - 06044b7e623b98f9f1edc14a0010f131
       Cache-Control:
       - no-cache, no-store
       Pragma:
@@ -44,24 +44,25 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"62866dc40f21442dfc971ad3b92d8859"
+      - W/"0335bb59c7e278f932ac2f6fb31f98a0"
       X-Runtime:
-      - '0.037620'
+      - '0.047383'
       Transfer-Encoding:
       - chunked
       X-Node:
-      - bigweb8nuq
+      - bigweb3nuq
       X-Version-Label:
-      - easypost-202203182244-fb6aae87d1-master
+      - easypost-202203231943-61a988cd70-master
       X-Backend:
       - easypost
       X-Proxied:
-      - extlb2nuq 3e97db20d4
+      - extlb1wdc 3e97db20d4
       - intlb1nuq 3e97db20d4
+      - intlb1wdc 3e97db20d4
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"shprep_1b2712c54fa34a4a892e96c38c6088af","object":"ShipmentReport","created_at":"2022-03-21T21:37:23Z","updated_at":"2022-03-21T21:37:23Z","start_date":"2022-02-21","end_date":"2022-02-23","mode":"test","status":"new","url":null,"url_expires_at":null,"include_children":false}'
-  recorded_at: Mon, 21 Mar 2022 21:37:23 GMT
+      string: '{"id":"shprep_abeac8a80e4a45c88465e41af408d117","object":"ShipmentReport","created_at":"2022-03-23T22:02:33Z","updated_at":"2022-03-23T22:02:33Z","start_date":"2022-02-21","end_date":"2022-02-23","mode":"test","status":"new","url":null,"url_expires_at":null,"include_children":false}'
+  recorded_at: Wed, 23 Mar 2022 22:02:33 GMT
 recorded_with: VCR 6.0.0


### PR DESCRIPTION
- Report columns go in JSON body, not query params
- Re-record cassettes