### PR TITLE
chore: remove dead message and carrier address verify code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # CHANGELOG
 
-## Next release
-* Add support for `columns` and `additional_columns` on Report creation
+## NEXT RELEASE
+
+- Add support for `columns` and `additional_columns` on Report creation
+- Removes the unusable `carrier` param from `Address.create_and_verify` along with the dead `message` conditional check
 
 ## v4.1.2 (2022-03-16)
 

--- a/lib/easypost/address.rb
+++ b/lib/easypost/address.rb
@@ -28,17 +28,12 @@ class EasyPost::Address < EasyPost::Resource
   end
 
   # Create and verify an Address in one call.
-  def self.create_and_verify(params = {}, carrier = nil, api_key = nil)
+  def self.create_and_verify(params = {}, api_key = nil)
     wrapped_params = {}
     wrapped_params[class_name.to_sym] = params
-    wrapped_params[:carrier] = carrier
     response = EasyPost.make_request(:post, "#{url}/create_and_verify", api_key, wrapped_params)
 
     raise EasyPost::Error.new('Unable to verify address.') unless response.key?('address')
-
-    if response.key?('message')
-      response['address']['message'] = response['message']
-    end
 
     EasyPost::Util.convert_to_easypost_object(response['address'], api_key)
   end

--- a/spec/address_spec.rb
+++ b/spec/address_spec.rb
@@ -32,7 +32,7 @@ describe EasyPost::Address do
 
       expect(address).to be_an_instance_of(described_class)
       expect(address.id).to match('adr_')
-      expect(address.street1).to eq('417 MONTGOMERY ST STE 500')
+      expect(address.street1).to eq('417 MONTGOMERY ST FL 5')
     end
   end
 
@@ -67,7 +67,7 @@ describe EasyPost::Address do
 
       expect(address).to be_an_instance_of(described_class)
       expect(address.id).to match('adr_')
-      expect(address.street1).to eq('417 MONTGOMERY ST STE 500')
+      expect(address.street1).to eq('417 MONTGOMERY ST FL 5')
     end
   end
 
@@ -79,7 +79,7 @@ describe EasyPost::Address do
 
       expect(verified_address).to be_an_instance_of(described_class)
       expect(verified_address.id).to match('adr_')
-      expect(verified_address.street1).to eq('417 MONTGOMERY ST STE 500')
+      expect(verified_address.street1).to eq('417 MONTGOMERY ST FL 5')
     end
   end
 end

--- a/spec/cassettes/address/EasyPost_Address_create_and_verify_creates_a_verified_address.yml
+++ b/spec/cassettes/address/EasyPost_Address_create_and_verify_creates_a_verified_address.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://api.easypost.com/v2/addresses/create_and_verify
     body:
       encoding: UTF-8
-      string: '{"address":{"verify":[true],"street1":"417 montgomery streat","street2":"FL
+      string: '{"address":{"verify":[true],"street1":"417 montgomery street","street2":"FL
         5","city":"San Francisco","state":"CA","zip":"94104","country":"US","company":"EasyPost","phone":"415-123-4567"}}'
     headers:
       Accept-Encoding:
@@ -13,7 +13,7 @@ http_interactions:
       Accept:
       - "*/*"
       User-Agent:
-      - EasyPost/v2 RubyClient/3.5.0 Ruby/3.1.0-p0
+      - EasyPost/v2 RubyClient/4.1.2 Ruby/3.1.1-p18
       Content-Type:
       - application/json
       Authorization: "<AUTHORIZATION>"
@@ -35,7 +35,7 @@ http_interactions:
       Referrer-Policy:
       - strict-origin-when-cross-origin
       X-Ep-Request-Uuid:
-      - 15c6b80c62166e83e786a7de002763dc
+      - 949d8845624f19e9e2b7d5f0001699db
       Cache-Control:
       - no-cache, no-store
       Pragma:
@@ -43,32 +43,32 @@ http_interactions:
       Expires:
       - '0'
       Location:
-      - "/api/v2/addresses/adr_e17b638394cd11ecaa36ac1f6bc72124"
+      - "/api/v2/addresses/adr_f6b093e0b69411ec9faaac1f6bc7b362"
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"43a0f003d7eb2dc944040fa568ba4968"
-      X-Request-Id:
-      - 3bfb9fdc-7b6b-49e0-bdea-a4bf4ab5713a
+      - W/"ae57ca7997a01c319a5ad5044d8279a6"
       X-Runtime:
-      - '0.046952'
+      - '0.042239'
       Transfer-Encoding:
       - chunked
       X-Node:
-      - bigweb3nuq
+      - bigweb4nuq
       X-Version-Label:
-      - easypost-202202230129-176eb4912d-master
+      - easypost-202204061951-19f0d1d0cc-master
       X-Backend:
       - easypost
       X-Proxied:
-      - extlb3wdc 88c34981dc
-      - intlb2nuq 88c34981dc
-      - intlb2wdc 88c34981dc
+      - extlb3wdc fde591f008
+      - intlb1wdc fde591f008
+      - intlb2nuq fde591f008
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
     body:
       encoding: ASCII-8BIT
-      string: '{"address":{"id":"adr_e17b638394cd11ecaa36ac1f6bc72124","object":"Address","created_at":"2022-02-23T17:27:31+00:00","updated_at":"2022-02-23T17:27:31+00:00","name":null,"company":"EASYPOST","street1":"417
-        MONTGOMERY ST STE 500","street2":"","city":"SAN FRANCISCO","state":"CA","zip":"94104-1100","country":"US","phone":"4151234567","email":null,"mode":"test","carrier_facility":null,"residential":false,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.79342,"longitude":-122.40288,"time_zone":"America/Los_Angeles"}}}}}'
-  recorded_at: Wed, 23 Feb 2022 17:27:31 GMT
+      string: '{"address":{"id":"adr_f6b093e0b69411ec9faaac1f6bc7b362","object":"Address","created_at":"2022-04-07T17:05:45+00:00","updated_at":"2022-04-07T17:05:45+00:00","name":null,"company":"EASYPOST","street1":"417
+        MONTGOMERY ST FL 5","street2":"","city":"SAN FRANCISCO","state":"CA","zip":"94104-1129","country":"US","phone":"4151234567","email":null,"mode":"test","carrier_facility":null,"residential":false,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[{"code":"E.SECONDARY_INFORMATION.INVALID","field":"street2","message":"Invalid
+        secondary information(Apt/Suite#)","suggestion":null}],"details":null},"delivery":{"success":true,"errors":[{"code":"E.SECONDARY_INFORMATION.INVALID","field":"street2","message":"Invalid
+        secondary information(Apt/Suite#)","suggestion":null}],"details":{"latitude":37.79342,"longitude":-122.40288,"time_zone":"America/Los_Angeles"}}}}}'
+  recorded_at: Thu, 07 Apr 2022 17:05:45 GMT
 recorded_with: VCR 6.0.0

--- a/spec/cassettes/address/EasyPost_Address_create_creates_an_address_with_verify_param.yml
+++ b/spec/cassettes/address/EasyPost_Address_create_creates_an_address_with_verify_param.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://api.easypost.com/v2/addresses?verify%5B%5D=true
     body:
       encoding: UTF-8
-      string: '{"address":{"street1":"417 montgomery streat","street2":"FL 5","city":"San
+      string: '{"address":{"street1":"417 montgomery street","street2":"FL 5","city":"San
         Francisco","state":"CA","zip":"94104","country":"US","company":"EasyPost","phone":"415-123-4567"}}'
     headers:
       Accept-Encoding:
@@ -13,7 +13,7 @@ http_interactions:
       Accept:
       - "*/*"
       User-Agent:
-      - EasyPost/v2 RubyClient/3.5.0 Ruby/3.1.0-p0
+      - EasyPost/v2 RubyClient/4.1.2 Ruby/3.1.1-p18
       Content-Type:
       - application/json
       Authorization: "<AUTHORIZATION>"
@@ -35,7 +35,7 @@ http_interactions:
       Referrer-Policy:
       - strict-origin-when-cross-origin
       X-Ep-Request-Uuid:
-      - 15c6b80e62166e80e786a7c30027630c
+      - 7f98dbad624f19f7e2b7d5f300190cf6
       Cache-Control:
       - no-cache, no-store
       Pragma:
@@ -43,34 +43,31 @@ http_interactions:
       Expires:
       - '0'
       Location:
-      - "/api/v2/addresses/adr_e018495d94cd11ecab36ac1f6b0a0d1e"
+      - "/api/v2/addresses/adr_ff1bc6ffb69411ecadb0ac1f6b0a0d1e"
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"92e9b556d5ed9281ff8d894d19c54d1a"
-      X-Request-Id:
-      - 6dbf5a13-221f-49c4-a93d-600bdff15344
+      - W/"f01ff395ebde02986447edf8f94dee5c"
       X-Runtime:
-      - '0.044419'
+      - '0.043787'
       Transfer-Encoding:
       - chunked
       X-Node:
-      - bigweb7nuq
+      - bigweb5nuq
       X-Version-Label:
-      - easypost-202202231719-cc169b5e93-master
+      - easypost-202204061951-19f0d1d0cc-master
       X-Backend:
       - easypost
-      X-Canary:
-      - direct
       X-Proxied:
-      - extlb3wdc 88c34981dc
-      - intlb2nuq 88c34981dc
-      - intlb2wdc 88c34981dc
+      - extlb1nuq fde591f008
+      - intlb1nuq fde591f008
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"adr_e018495d94cd11ecab36ac1f6b0a0d1e","object":"Address","created_at":"2022-02-23T17:27:29+00:00","updated_at":"2022-02-23T17:27:29+00:00","name":null,"company":"EASYPOST","street1":"417
-        MONTGOMERY ST STE 500","street2":"","city":"SAN FRANCISCO","state":"CA","zip":"94104-1100","country":"US","phone":"4151234567","email":null,"mode":"test","carrier_facility":null,"residential":false,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.79342,"longitude":-122.40288,"time_zone":"America/Los_Angeles"}}}}'
-  recorded_at: Wed, 23 Feb 2022 17:27:29 GMT
+      string: '{"id":"adr_ff1bc6ffb69411ecadb0ac1f6b0a0d1e","object":"Address","created_at":"2022-04-07T17:05:59+00:00","updated_at":"2022-04-07T17:05:59+00:00","name":null,"company":"EASYPOST","street1":"417
+        MONTGOMERY ST FL 5","street2":"","city":"SAN FRANCISCO","state":"CA","zip":"94104-1129","country":"US","phone":"4151234567","email":null,"mode":"test","carrier_facility":null,"residential":false,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[{"code":"E.SECONDARY_INFORMATION.INVALID","field":"street2","message":"Invalid
+        secondary information(Apt/Suite#)","suggestion":null}],"details":null},"delivery":{"success":true,"errors":[{"code":"E.SECONDARY_INFORMATION.INVALID","field":"street2","message":"Invalid
+        secondary information(Apt/Suite#)","suggestion":null}],"details":{"latitude":37.79342,"longitude":-122.40288,"time_zone":"America/Los_Angeles"}}}}'
+  recorded_at: Thu, 07 Apr 2022 17:05:59 GMT
 recorded_with: VCR 6.0.0

--- a/spec/cassettes/address/EasyPost_Address_verify_verifies_an_already_created_address.yml
+++ b/spec/cassettes/address/EasyPost_Address_verify_verifies_an_already_created_address.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://api.easypost.com/v2/addresses?verify%5B%5D=true
     body:
       encoding: UTF-8
-      string: '{"address":{"street1":"417 montgomery streat","street2":"FL 5","city":"San
+      string: '{"address":{"street1":"417 montgomery street","street2":"FL 5","city":"San
         Francisco","state":"CA","zip":"94104","country":"US","company":"EasyPost","phone":"415-123-4567"}}'
     headers:
       Accept-Encoding:
@@ -13,7 +13,7 @@ http_interactions:
       Accept:
       - "*/*"
       User-Agent:
-      - EasyPost/v2 RubyClient/3.5.0 Ruby/3.1.0-p0
+      - EasyPost/v2 RubyClient/4.1.2 Ruby/3.1.1-p18
       Content-Type:
       - application/json
       Authorization: "<AUTHORIZATION>"
@@ -35,7 +35,7 @@ http_interactions:
       Referrer-Policy:
       - strict-origin-when-cross-origin
       X-Ep-Request-Uuid:
-      - 15c6b80d62166e83e786a7df00276409
+      - 949d8849624f19e9e2b7d5f100169a03
       Cache-Control:
       - no-cache, no-store
       Pragma:
@@ -43,37 +43,37 @@ http_interactions:
       Expires:
       - '0'
       Location:
-      - "/api/v2/addresses/adr_e1cae5fb94cd11ecab95ac1f6b0a0d1e"
+      - "/api/v2/addresses/adr_f6e63bdeb69411ec9fbfac1f6bc7b362"
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"5e2bfebe3716f4c661ab122b8fe9287d"
-      X-Request-Id:
-      - bf830e28-0995-4ae5-a78b-cd795630c6a0
+      - W/"8bfc62c2ea230c5d49fb3f2964d59bde"
       X-Runtime:
-      - '0.047791'
+      - '0.044115'
       Transfer-Encoding:
       - chunked
       X-Node:
       - bigweb5nuq
       X-Version-Label:
-      - easypost-202202230129-176eb4912d-master
+      - easypost-202204061951-19f0d1d0cc-master
       X-Backend:
       - easypost
       X-Proxied:
-      - extlb3wdc 88c34981dc
-      - intlb1nuq 88c34981dc
-      - intlb2wdc 88c34981dc
+      - extlb3wdc fde591f008
+      - intlb2nuq fde591f008
+      - intlb2wdc fde591f008
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"adr_e1cae5fb94cd11ecab95ac1f6b0a0d1e","object":"Address","created_at":"2022-02-23T17:27:31+00:00","updated_at":"2022-02-23T17:27:31+00:00","name":null,"company":"EASYPOST","street1":"417
-        MONTGOMERY ST STE 500","street2":"","city":"SAN FRANCISCO","state":"CA","zip":"94104-1100","country":"US","phone":"4151234567","email":null,"mode":"test","carrier_facility":null,"residential":false,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.79342,"longitude":-122.40288,"time_zone":"America/Los_Angeles"}}}}'
-  recorded_at: Wed, 23 Feb 2022 17:27:31 GMT
+      string: '{"id":"adr_f6e63bdeb69411ec9fbfac1f6bc7b362","object":"Address","created_at":"2022-04-07T17:05:45+00:00","updated_at":"2022-04-07T17:05:45+00:00","name":null,"company":"EASYPOST","street1":"417
+        MONTGOMERY ST FL 5","street2":"","city":"SAN FRANCISCO","state":"CA","zip":"94104-1129","country":"US","phone":"4151234567","email":null,"mode":"test","carrier_facility":null,"residential":false,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[{"code":"E.SECONDARY_INFORMATION.INVALID","field":"street2","message":"Invalid
+        secondary information(Apt/Suite#)","suggestion":null}],"details":null},"delivery":{"success":true,"errors":[{"code":"E.SECONDARY_INFORMATION.INVALID","field":"street2","message":"Invalid
+        secondary information(Apt/Suite#)","suggestion":null}],"details":{"latitude":37.79342,"longitude":-122.40288,"time_zone":"America/Los_Angeles"}}}}'
+  recorded_at: Thu, 07 Apr 2022 17:05:45 GMT
 - request:
     method: get
-    uri: https://api.easypost.com/v2/addresses/adr_e1cae5fb94cd11ecab95ac1f6b0a0d1e/verify
+    uri: https://api.easypost.com/v2/addresses/adr_f6e63bdeb69411ec9fbfac1f6bc7b362/verify
     body:
       encoding: US-ASCII
       string: ''
@@ -83,7 +83,7 @@ http_interactions:
       Accept:
       - "*/*"
       User-Agent:
-      - EasyPost/v2 RubyClient/3.5.0 Ruby/3.1.0-p0
+      - EasyPost/v2 RubyClient/4.1.2 Ruby/3.1.1-p18
       Content-Type:
       - application/json
       Authorization: "<AUTHORIZATION>"
@@ -105,7 +105,7 @@ http_interactions:
       Referrer-Policy:
       - strict-origin-when-cross-origin
       X-Ep-Request-Uuid:
-      - 15c6b80962166e84e786a7e00027642a
+      - 949d8849624f19e9e2b7d5f200169a28
       Cache-Control:
       - no-cache, no-store
       Pragma:
@@ -113,32 +113,32 @@ http_interactions:
       Expires:
       - '0'
       Location:
-      - "/api/v2/addresses/adr_e21bdb1f94cd11ecb368ac1f6bc7b362"
+      - "/api/v2/addresses/adr_f71a3987b69411ec9fcdac1f6bc7b362"
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"e58134bb96f6d355bb3045b99443de3c"
-      X-Request-Id:
-      - e12728a2-1cef-47e7-b5ea-7084a9ac4e25
+      - W/"bf8f2ab01d0352aebc55ff4a11a02a02"
       X-Runtime:
-      - '0.052668'
+      - '0.053337'
       Transfer-Encoding:
       - chunked
       X-Node:
-      - bigweb2nuq
+      - bigweb5nuq
       X-Version-Label:
-      - easypost-202202230129-176eb4912d-master
+      - easypost-202204061951-19f0d1d0cc-master
       X-Backend:
       - easypost
       X-Proxied:
-      - extlb3wdc 88c34981dc
-      - intlb1nuq 88c34981dc
-      - intlb1wdc 88c34981dc
+      - extlb3wdc fde591f008
+      - intlb1nuq fde591f008
+      - intlb2wdc fde591f008
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
     body:
       encoding: ASCII-8BIT
-      string: '{"address":{"id":"adr_e21bdb1f94cd11ecb368ac1f6bc7b362","object":"Address","created_at":"2022-02-23T17:27:32+00:00","updated_at":"2022-02-23T17:27:32+00:00","name":null,"company":"EASYPOST","street1":"417
-        MONTGOMERY ST STE 500","street2":"","city":"SAN FRANCISCO","state":"CA","zip":"94104-1100","country":"US","phone":"4151234567","email":null,"mode":"test","carrier_facility":null,"residential":false,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.79342,"longitude":-122.40288,"time_zone":"America/Los_Angeles"}}}}}'
-  recorded_at: Wed, 23 Feb 2022 17:27:32 GMT
+      string: '{"address":{"id":"adr_f71a3987b69411ec9fcdac1f6bc7b362","object":"Address","created_at":"2022-04-07T17:05:45+00:00","updated_at":"2022-04-07T17:05:45+00:00","name":null,"company":"EASYPOST","street1":"417
+        MONTGOMERY ST FL 5","street2":"","city":"SAN FRANCISCO","state":"CA","zip":"94104-1129","country":"US","phone":"4151234567","email":null,"mode":"test","carrier_facility":null,"residential":false,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[{"code":"E.SECONDARY_INFORMATION.INVALID","field":"street2","message":"Invalid
+        secondary information(Apt/Suite#)","suggestion":null}],"details":null},"delivery":{"success":true,"errors":[{"code":"E.SECONDARY_INFORMATION.INVALID","field":"street2","message":"Invalid
+        secondary information(Apt/Suite#)","suggestion":null}],"details":{"latitude":37.79342,"longitude":-122.40288,"time_zone":"America/Los_Angeles"}}}}}'
+  recorded_at: Thu, 07 Apr 2022 17:05:45 GMT
 recorded_with: VCR 6.0.0

--- a/spec/refund_spec.rb
+++ b/spec/refund_spec.rb
@@ -35,7 +35,7 @@ describe EasyPost::Refund do
   describe '.retrieve' do
     it 'retrieves a refund' do
       shipment = EasyPost::Shipment.create(Fixture.one_call_buy_shipment)
-      retrieved_shipment = EasyPost::Shipment.retrieve(shipment.id) # We need to retrieve the shipment so that the tracking_code has time to populat
+      retrieved_shipment = EasyPost::Shipment.retrieve(shipment.id) # We need to retrieve the shipment so that the tracking_code has time to populate
 
       refund = described_class.create(
         carrier: Fixture.usps,

--- a/spec/support/fixture.rb
+++ b/spec/support/fixture.rb
@@ -51,7 +51,7 @@ class Fixture
   def self.incorrect_address_to_verify
     {
       verify: [true],
-      street1: '417 montgomery streat',
+      street1: '417 montgomery street',
       street2: 'FL 5',
       city: 'San Francisco',
       state: 'CA',


### PR DESCRIPTION
- Removes the unusable `carrier` param from `Address.create_and_verify` along with the dead `message` conditional check
- Updates a few address assertions to match internal API changes