### PR TITLE
fix: revert to hard-coded test dates

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,3 +129,5 @@ The test suite in this project was specifically built to produce consistent resu
 If you make an addition to this project, the request/response will get recorded automatically for you. When making changes to this project, you'll need to re-record the associated cassette to force a new live API call for that test which will then record the request/response used on the next run.
 
 The test suite has been populated with various helpful fixtures that are available for use, each completely independent from a particular user **with the exception of the USPS carrier account ID** which has a fallback value to our internal testing user's ID. If you are a non-EasyPost employee and are re-recording cassettes, you may need to provide the `USPS_CARRIER_ACCOUNT_ID` environment variable with the ID associated with your USPS account (which will be associated with your API keys in use) for tests that use this fixture.
+
+**Note on dates:** Some fixtures use hard-coded dates that may need to be incremented if cassettes get re-recorded (such as reports or pickups).

--- a/spec/cassettes/pickup/EasyPost_Pickup_buy_buys_a_pickup.yml
+++ b/spec/cassettes/pickup/EasyPost_Pickup_buy_buys_a_pickup.yml
@@ -15,7 +15,7 @@ http_interactions:
       Accept:
       - "*/*"
       User-Agent:
-      - EasyPost/v2 RubyClient/3.5.0 Ruby/3.1.0-p0
+      - EasyPost/v2 RubyClient/4.1.2 Ruby/3.1.1-p18
       Content-Type:
       - application/json
       Authorization: "<AUTHORIZATION>"
@@ -37,7 +37,7 @@ http_interactions:
       Referrer-Policy:
       - strict-origin-when-cross-origin
       X-Ep-Request-Uuid:
-      - 7b4066386216a7c7e788f72d00418100
+      - '0991fb55625474c5e786b3fe00232d7c'
       Cache-Control:
       - no-cache, no-store
       Pragma:
@@ -45,55 +45,53 @@ http_interactions:
       Expires:
       - '0'
       Location:
-      - "/api/v2/shipments/shp_e777bea5f66b4382b51787da0bedd772"
+      - "/api/v2/shipments/shp_89c8b7cacc8d424b9fcae6c5b91a5333"
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"d4d85f498cfaa7cbb9bbcde4ae78e93f"
-      X-Request-Id:
-      - 923ab129-6ef3-4b07-8451-7b920c049aa5
+      - W/"341cad3a6c4d220661aacf2e3f2af6de"
       X-Runtime:
-      - '0.850872'
+      - '0.953641'
       Transfer-Encoding:
       - chunked
       X-Node:
-      - bigweb3nuq
+      - bigweb4nuq
       X-Version-Label:
-      - easypost-202202232103-87ed4a9d34-master
+      - easypost-202204082123-da17cc1ac2-master
       X-Backend:
       - easypost
       X-Proxied:
-      - extlb2nuq 88c34981dc
-      - intlb2nuq 88c34981dc
+      - extlb2nuq fde591f008
+      - intlb2nuq fde591f008
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
     body:
       encoding: ASCII-8BIT
-      string: '{"created_at":"2022-02-23T21:31:51Z","is_return":false,"messages":[],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":"9400100895232108754370","updated_at":"2022-02-23T21:31:52Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_03b2ed5b94f011ec9ebcac1f6b0a0d1e","object":"Address","created_at":"2022-02-23T21:31:51+00:00","updated_at":"2022-02-23T21:31:51+00:00","name":"Jack
+      string: '{"created_at":"2022-04-11T18:34:45Z","is_return":false,"messages":[],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":"9400100109361114522113","updated_at":"2022-04-11T18:34:46Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_0f4a33bbb9c611ec9b71ac1f6bc72124","object":"Address","created_at":"2022-04-11T18:34:45+00:00","updated_at":"2022-04-11T18:34:45+00:00","name":"Jack
         Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_32fceb94ccfc4c499a50513dfe94655f","object":"Parcel","created_at":"2022-02-23T21:31:51Z","updated_at":"2022-02-23T21:31:51Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":{"object":"PostageLabel","id":"pl_2db60b57e98d49209052f281be329413","created_at":"2022-02-23T21:31:52Z","updated_at":"2022-02-23T21:31:52Z","date_advance":0,"integrated_form":"none","label_date":"2022-02-23T21:31:52Z","label_resolution":300,"label_size":"4x6","label_type":"default","label_file_type":"image/png","label_url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220223/3f6763659df24f59b57a6f04a1203e4d.png","label_pdf_url":null,"label_zpl_url":null,"label_epl2_url":null,"label_file":null},"rates":[{"id":"rate_3dd4990f6ae04425ad137828ba2050aa","object":"Rate","created_at":"2022-02-23T21:31:51Z","updated_at":"2022-02-23T21:31:51Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_e777bea5f66b4382b51787da0bedd772","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},{"id":"rate_e391fc32067b4d6e98721baeae11a417","object":"Rate","created_at":"2022-02-23T21:31:51Z","updated_at":"2022-02-23T21:31:51Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_e777bea5f66b4382b51787da0bedd772","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},{"id":"rate_c38776edf14041719de2c5b1e0af23de","object":"Rate","created_at":"2022-02-23T21:31:51Z","updated_at":"2022-02-23T21:31:51Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_e777bea5f66b4382b51787da0bedd772","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},{"id":"rate_9f1bba98ca9e44b4955a688d7638ba4a","object":"Rate","created_at":"2022-02-23T21:31:51Z","updated_at":"2022-02-23T21:31:51Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_e777bea5f66b4382b51787da0bedd772","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"}],"refund_status":null,"scan_form":null,"selected_rate":{"id":"rate_9f1bba98ca9e44b4955a688d7638ba4a","object":"Rate","created_at":"2022-02-23T21:31:52Z","updated_at":"2022-02-23T21:31:52Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_e777bea5f66b4382b51787da0bedd772","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},"tracker":{"id":"trk_6dba6d7e4d884c9b80ed48049926713e","object":"Tracker","mode":"test","tracking_code":"9400100895232108754370","status":"unknown","status_detail":"unknown","created_at":"2022-02-23T21:31:52Z","updated_at":"2022-02-23T21:31:52Z","signed_by":null,"weight":null,"est_delivery_date":null,"shipment_id":"shp_e777bea5f66b4382b51787da0bedd772","carrier":"USPS","tracking_details":[],"fees":[],"carrier_detail":null,"public_url":"https://track.easypost.com/djE6dHJrXzZkYmE2ZDdlNGQ4ODRjOWI4MGVkNDgwNDk5MjY3MTNl"},"to_address":{"id":"adr_03b1016294f011ec9ebbac1f6b0a0d1e","object":"Address","created_at":"2022-02-23T21:31:51+00:00","updated_at":"2022-02-23T21:31:51+00:00","name":"JACK
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_a175ade726814579878b3a1909587176","object":"Parcel","created_at":"2022-04-11T18:34:45Z","updated_at":"2022-04-11T18:34:45Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":{"object":"PostageLabel","id":"pl_f9752b2e2dfe4fb1a2543848196cc224","created_at":"2022-04-11T18:34:45Z","updated_at":"2022-04-11T18:34:46Z","date_advance":0,"integrated_form":"none","label_date":"2022-04-11T18:34:45Z","label_resolution":300,"label_size":"4x6","label_type":"default","label_file_type":"image/png","label_url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220411/b86f568e7eb94865aadb7df3c41d8d85.png","label_pdf_url":null,"label_zpl_url":null,"label_epl2_url":null,"label_file":null},"rates":[{"id":"rate_9667fbb152b3487a833dbe8956477bc4","object":"Rate","created_at":"2022-04-11T18:34:45Z","updated_at":"2022-04-11T18:34:45Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_89c8b7cacc8d424b9fcae6c5b91a5333","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},{"id":"rate_56ad7afefc61412e877dbd3a4885cea9","object":"Rate","created_at":"2022-04-11T18:34:45Z","updated_at":"2022-04-11T18:34:45Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_89c8b7cacc8d424b9fcae6c5b91a5333","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},{"id":"rate_939f758ca4e44c518cd7d46829d40d8f","object":"Rate","created_at":"2022-04-11T18:34:45Z","updated_at":"2022-04-11T18:34:45Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_89c8b7cacc8d424b9fcae6c5b91a5333","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},{"id":"rate_425ad05db5204499a394e1ae4b05f080","object":"Rate","created_at":"2022-04-11T18:34:45Z","updated_at":"2022-04-11T18:34:45Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_89c8b7cacc8d424b9fcae6c5b91a5333","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"}],"refund_status":null,"scan_form":null,"selected_rate":{"id":"rate_9667fbb152b3487a833dbe8956477bc4","object":"Rate","created_at":"2022-04-11T18:34:45Z","updated_at":"2022-04-11T18:34:45Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_89c8b7cacc8d424b9fcae6c5b91a5333","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},"tracker":{"id":"trk_fa5de6462188490db981584e0514bc1f","object":"Tracker","mode":"test","tracking_code":"9400100109361114522113","status":"unknown","status_detail":"unknown","created_at":"2022-04-11T18:34:46Z","updated_at":"2022-04-11T18:34:46Z","signed_by":null,"weight":null,"est_delivery_date":null,"shipment_id":"shp_89c8b7cacc8d424b9fcae6c5b91a5333","carrier":"USPS","tracking_details":[],"fees":[],"carrier_detail":null,"public_url":"https://track.easypost.com/djE6dHJrX2ZhNWRlNjQ2MjE4ODQ5MGRiOTgxNTg0ZTA1MTRiYzFm"},"to_address":{"id":"adr_0f4857d1b9c611ec9b6fac1f6bc72124","object":"Address","created_at":"2022-04-11T18:34:45+00:00","updated_at":"2022-04-11T18:34:45+00:00","name":"JACK
         SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN
-        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"usps_zone":1,"return_address":{"id":"adr_03b2ed5b94f011ec9ebcac1f6b0a0d1e","object":"Address","created_at":"2022-02-23T21:31:51+00:00","updated_at":"2022-02-23T21:31:51+00:00","name":"Jack
+        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"usps_zone":1,"return_address":{"id":"adr_0f4a33bbb9c611ec9b71ac1f6bc72124","object":"Address","created_at":"2022-04-11T18:34:45+00:00","updated_at":"2022-04-11T18:34:45+00:00","name":"Jack
         Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_03b1016294f011ec9ebbac1f6b0a0d1e","object":"Address","created_at":"2022-02-23T21:31:51+00:00","updated_at":"2022-02-23T21:31:51+00:00","name":"JACK
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_0f4857d1b9c611ec9b6fac1f6bc72124","object":"Address","created_at":"2022-04-11T18:34:45+00:00","updated_at":"2022-04-11T18:34:45+00:00","name":"JACK
         SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN
-        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"forms":[],"fees":[{"object":"Fee","type":"LabelFee","amount":"0.01000","charged":true,"refunded":false},{"object":"Fee","type":"PostageFee","amount":"5.49000","charged":true,"refunded":false}],"id":"shp_e777bea5f66b4382b51787da0bedd772","object":"Shipment"}'
-  recorded_at: Wed, 23 Feb 2022 21:31:52 GMT
+        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"forms":[],"fees":[{"object":"Fee","type":"LabelFee","amount":"0.01000","charged":true,"refunded":false},{"object":"Fee","type":"PostageFee","amount":"5.49000","charged":true,"refunded":false}],"id":"shp_89c8b7cacc8d424b9fcae6c5b91a5333","object":"Shipment"}'
+  recorded_at: Mon, 11 Apr 2022 18:34:46 GMT
 - request:
     method: post
     uri: https://api.easypost.com/v2/pickups
     body:
       encoding: UTF-8
       string: '{"pickup":{"address":{"name":"Jack Sparrow","company":"EasyPost","street1":"388
-        Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","phone":"5555555555"},"min_datetime":"2022-02-24","max_datetime":"2022-02-25","instructions":"Pickup
-        at front door","shipment":{"id":"shp_e777bea5f66b4382b51787da0bedd772"}}}'
+        Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","phone":"5555555555"},"min_datetime":"2022-04-12","max_datetime":"2022-04-12","instructions":"Pickup
+        at front door","shipment":{"id":"shp_89c8b7cacc8d424b9fcae6c5b91a5333"}}}'
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
       User-Agent:
-      - EasyPost/v2 RubyClient/3.5.0 Ruby/3.1.0-p0
+      - EasyPost/v2 RubyClient/4.1.2 Ruby/3.1.1-p18
       Content-Type:
       - application/json
       Authorization: "<AUTHORIZATION>"
@@ -115,7 +113,7 @@ http_interactions:
       Referrer-Policy:
       - strict-origin-when-cross-origin
       X-Ep-Request-Uuid:
-      - 7b4066396216a7c8e788f72e00418158
+      - '0991fb56625474c6e786b3ff00232dd5'
       Cache-Control:
       - no-cache, no-store
       Pragma:
@@ -125,34 +123,32 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"1a287df84fa785afffe53c136900776e"
-      X-Request-Id:
-      - 936faebf-8cd9-4529-a3ec-2520cc7ccfe7
+      - W/"2701402724fd8b7b412303beb3ea7b06"
       X-Runtime:
-      - '0.778185'
+      - '0.766075'
       Transfer-Encoding:
       - chunked
       X-Node:
-      - bigweb8nuq
+      - bigweb6nuq
       X-Version-Label:
-      - easypost-202202232103-87ed4a9d34-master
+      - easypost-202204082123-da17cc1ac2-master
       X-Backend:
       - easypost
       X-Proxied:
-      - extlb2nuq 88c34981dc
-      - intlb2nuq 88c34981dc
+      - extlb2nuq fde591f008
+      - intlb2nuq fde591f008
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"pickup_2c4c19949c2e4b47bfb4df367f27a41f","object":"Pickup","created_at":"2022-02-23T21:31:52Z","updated_at":"2022-02-23T21:31:52Z","mode":"test","status":"unknown","reference":null,"min_datetime":"2022-02-24T00:00:00Z","max_datetime":"2022-02-25T00:00:00Z","is_account_address":false,"instructions":"Pickup
-        at front door","messages":[],"confirmation":null,"address":{"id":"adr_044fa8ca94f011eca91bac1f6bc7b362","object":"Address","created_at":"2022-02-23T21:31:52+00:00","updated_at":"2022-02-23T21:31:52+00:00","name":"Jack
+      string: '{"id":"pickup_4a157bd73ac249d683ad717e34ba2a33","object":"Pickup","created_at":"2022-04-11T18:34:46Z","updated_at":"2022-04-11T18:34:46Z","mode":"test","status":"unknown","reference":null,"min_datetime":"2022-04-12T00:00:00Z","max_datetime":"2022-04-12T00:00:00Z","is_account_address":false,"instructions":"Pickup
+        at front door","messages":[],"confirmation":null,"address":{"id":"adr_0ff7144cb9c611ec9ba3ac1f6bc72124","object":"Address","created_at":"2022-04-11T18:34:46+00:00","updated_at":"2022-04-11T18:34:46+00:00","name":"Jack
         Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"carrier_accounts":[],"pickup_rates":[{"mode":"test","service":"NextDay","rate":"0.00","currency":"USD","created_at":"2022-02-23T21:31:53Z","updated_at":"2022-02-23T21:31:53Z","carrier":"USPS","pickup_id":"pickup_2c4c19949c2e4b47bfb4df367f27a41f","id":"pickuprate_360608c2eda340b3a57e334d5dd34ac5","object":"PickupRate"}]}'
-  recorded_at: Wed, 23 Feb 2022 21:31:53 GMT
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"carrier_accounts":[],"pickup_rates":[{"mode":"test","service":"NextDay","rate":"0.00","currency":"USD","created_at":"2022-04-11T18:34:47Z","updated_at":"2022-04-11T18:34:47Z","carrier":"USPS","pickup_id":"pickup_4a157bd73ac249d683ad717e34ba2a33","id":"pickuprate_9f5b33aa06164f319b543ed0c8601b80","object":"PickupRate"}]}'
+  recorded_at: Mon, 11 Apr 2022 18:34:47 GMT
 - request:
     method: post
-    uri: https://api.easypost.com/v2/pickups/pickup_2c4c19949c2e4b47bfb4df367f27a41f/buy
+    uri: https://api.easypost.com/v2/pickups/pickup_4a157bd73ac249d683ad717e34ba2a33/buy
     body:
       encoding: UTF-8
       string: '{"carrier":"USPS","service":"NextDay"}'
@@ -162,7 +158,7 @@ http_interactions:
       Accept:
       - "*/*"
       User-Agent:
-      - EasyPost/v2 RubyClient/3.5.0 Ruby/3.1.0-p0
+      - EasyPost/v2 RubyClient/4.1.2 Ruby/3.1.1-p18
       Content-Type:
       - application/json
       Authorization: "<AUTHORIZATION>"
@@ -184,7 +180,7 @@ http_interactions:
       Referrer-Policy:
       - strict-origin-when-cross-origin
       X-Ep-Request-Uuid:
-      - 7b40663b6216a7c9e788f72f00418195
+      - '0991fb57625474c7e786b40000232e37'
       Cache-Control:
       - no-cache, no-store
       Pragma:
@@ -194,29 +190,27 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"28e36d577f7dc947e73604a72bc1dc08"
-      X-Request-Id:
-      - 48bb055e-4fc4-499c-876d-ba657d4e4fe4
+      - W/"39c0f282173e4cd54d4e92419ad6a0d1"
       X-Runtime:
-      - '1.217898'
+      - '1.077607'
       Transfer-Encoding:
       - chunked
       X-Node:
-      - bigweb8nuq
+      - bigweb5nuq
       X-Version-Label:
-      - easypost-202202232103-87ed4a9d34-master
+      - easypost-202204082123-da17cc1ac2-master
       X-Backend:
       - easypost
       X-Proxied:
-      - extlb2nuq 88c34981dc
-      - intlb1nuq 88c34981dc
+      - extlb2nuq fde591f008
+      - intlb2nuq fde591f008
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"pickup_2c4c19949c2e4b47bfb4df367f27a41f","object":"Pickup","created_at":"2022-02-23T21:31:52Z","updated_at":"2022-02-23T21:31:54Z","mode":"test","status":"scheduled","reference":null,"min_datetime":"2022-02-24T00:00:00Z","max_datetime":"2022-02-25T00:00:00Z","is_account_address":false,"instructions":"Pickup
-        at front door","messages":[],"confirmation":"WTC61769222","address":{"id":"adr_044fa8ca94f011eca91bac1f6bc7b362","object":"Address","created_at":"2022-02-23T21:31:52+00:00","updated_at":"2022-02-23T21:31:52+00:00","name":"Jack
+      string: '{"id":"pickup_4a157bd73ac249d683ad717e34ba2a33","object":"Pickup","created_at":"2022-04-11T18:34:46Z","updated_at":"2022-04-11T18:34:48Z","mode":"test","status":"scheduled","reference":null,"min_datetime":"2022-04-12T00:00:00Z","max_datetime":"2022-04-12T00:00:00Z","is_account_address":false,"instructions":"Pickup
+        at front door","messages":[],"confirmation":"WTC61774816","address":{"id":"adr_0ff7144cb9c611ec9ba3ac1f6bc72124","object":"Address","created_at":"2022-04-11T18:34:46+00:00","updated_at":"2022-04-11T18:34:46+00:00","name":"Jack
         Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"carrier_accounts":[],"pickup_rates":[{"mode":"test","service":"NextDay","rate":"0.00","currency":"USD","created_at":"2022-02-23T21:31:53Z","updated_at":"2022-02-23T21:31:53Z","carrier":"USPS","pickup_id":"pickup_2c4c19949c2e4b47bfb4df367f27a41f","id":"pickuprate_360608c2eda340b3a57e334d5dd34ac5","object":"PickupRate"}]}'
-  recorded_at: Wed, 23 Feb 2022 21:31:54 GMT
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"carrier_accounts":[],"pickup_rates":[{"mode":"test","service":"NextDay","rate":"0.00","currency":"USD","created_at":"2022-04-11T18:34:47Z","updated_at":"2022-04-11T18:34:47Z","carrier":"USPS","pickup_id":"pickup_4a157bd73ac249d683ad717e34ba2a33","id":"pickuprate_9f5b33aa06164f319b543ed0c8601b80","object":"PickupRate"}]}'
+  recorded_at: Mon, 11 Apr 2022 18:34:48 GMT
 recorded_with: VCR 6.0.0

--- a/spec/cassettes/pickup/EasyPost_Pickup_cancel_cancels_a_pickup.yml
+++ b/spec/cassettes/pickup/EasyPost_Pickup_cancel_cancels_a_pickup.yml
@@ -15,7 +15,7 @@ http_interactions:
       Accept:
       - "*/*"
       User-Agent:
-      - EasyPost/v2 RubyClient/3.5.0 Ruby/3.1.0-p0
+      - EasyPost/v2 RubyClient/4.1.2 Ruby/3.1.1-p18
       Content-Type:
       - application/json
       Authorization: "<AUTHORIZATION>"
@@ -37,7 +37,7 @@ http_interactions:
       Referrer-Policy:
       - strict-origin-when-cross-origin
       X-Ep-Request-Uuid:
-      - 7b4066396216a7cbe788f747004181ec
+      - '0991fb52625474c8e786b40100232eb9'
       Cache-Control:
       - no-cache, no-store
       Pragma:
@@ -45,55 +45,53 @@ http_interactions:
       Expires:
       - '0'
       Location:
-      - "/api/v2/shipments/shp_40a7ab22b08e47d28fa8b400eb43fa14"
+      - "/api/v2/shipments/shp_238da2da32894d2396d8619b8e64f06d"
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"7e31e66ac91f4abcbce17e3ee2b35c14"
-      X-Request-Id:
-      - c4886e8f-c3a7-402e-8f03-b31fcb61b7d1
+      - W/"5da1d6ed7c70f8e690299de1d52174f9"
       X-Runtime:
-      - '1.022114'
+      - '0.930758'
       Transfer-Encoding:
       - chunked
       X-Node:
-      - bigweb1nuq
+      - bigweb9nuq
       X-Version-Label:
-      - easypost-202202232103-87ed4a9d34-master
+      - easypost-202204082123-da17cc1ac2-master
       X-Backend:
       - easypost
       X-Proxied:
-      - extlb2nuq 88c34981dc
-      - intlb1nuq 88c34981dc
+      - extlb2nuq fde591f008
+      - intlb2nuq fde591f008
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
     body:
       encoding: ASCII-8BIT
-      string: '{"created_at":"2022-02-23T21:31:55Z","is_return":false,"messages":[],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":"9400100895232108754387","updated_at":"2022-02-23T21:31:56Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_05be9e1b94f011eca969ac1f6bc7b362","object":"Address","created_at":"2022-02-23T21:31:55+00:00","updated_at":"2022-02-23T21:31:55+00:00","name":"Jack
+      string: '{"created_at":"2022-04-11T18:34:48Z","is_return":false,"messages":[],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":"9400100109361114522120","updated_at":"2022-04-11T18:34:49Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_116b748cb9c611ec83d9ac1f6bc7b362","object":"Address","created_at":"2022-04-11T18:34:48+00:00","updated_at":"2022-04-11T18:34:48+00:00","name":"Jack
         Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_a14987681436410584dcaa77209c45c4","object":"Parcel","created_at":"2022-02-23T21:31:55Z","updated_at":"2022-02-23T21:31:55Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":{"object":"PostageLabel","id":"pl_3b4f1af2b85145329dcc55f7454989b3","created_at":"2022-02-23T21:31:55Z","updated_at":"2022-02-23T21:31:55Z","date_advance":0,"integrated_form":"none","label_date":"2022-02-23T21:31:55Z","label_resolution":300,"label_size":"4x6","label_type":"default","label_file_type":"image/png","label_url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220223/90a096653eb4419ba24afc166fbfd6cb.png","label_pdf_url":null,"label_zpl_url":null,"label_epl2_url":null,"label_file":null},"rates":[{"id":"rate_c267b508c2b64df3960ee4ea393e479b","object":"Rate","created_at":"2022-02-23T21:31:55Z","updated_at":"2022-02-23T21:31:55Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_40a7ab22b08e47d28fa8b400eb43fa14","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},{"id":"rate_1319bee0baf6470aad54e173c828b37d","object":"Rate","created_at":"2022-02-23T21:31:55Z","updated_at":"2022-02-23T21:31:55Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_40a7ab22b08e47d28fa8b400eb43fa14","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},{"id":"rate_b898ab9791344c13803fd7cc762fb98a","object":"Rate","created_at":"2022-02-23T21:31:55Z","updated_at":"2022-02-23T21:31:55Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_40a7ab22b08e47d28fa8b400eb43fa14","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},{"id":"rate_80238b0c927e460bb60488751e5e5748","object":"Rate","created_at":"2022-02-23T21:31:55Z","updated_at":"2022-02-23T21:31:55Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_40a7ab22b08e47d28fa8b400eb43fa14","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"}],"refund_status":null,"scan_form":null,"selected_rate":{"id":"rate_b898ab9791344c13803fd7cc762fb98a","object":"Rate","created_at":"2022-02-23T21:31:55Z","updated_at":"2022-02-23T21:31:55Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_40a7ab22b08e47d28fa8b400eb43fa14","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},"tracker":{"id":"trk_d7a915d194ed4392b5db4d0a2f54d8be","object":"Tracker","mode":"test","tracking_code":"9400100895232108754387","status":"unknown","status_detail":"unknown","created_at":"2022-02-23T21:31:56Z","updated_at":"2022-02-23T21:31:56Z","signed_by":null,"weight":null,"est_delivery_date":null,"shipment_id":"shp_40a7ab22b08e47d28fa8b400eb43fa14","carrier":"USPS","tracking_details":[],"fees":[],"carrier_detail":null,"public_url":"https://track.easypost.com/djE6dHJrX2Q3YTkxNWQxOTRlZDQzOTJiNWRiNGQwYTJmNTRkOGJl"},"to_address":{"id":"adr_05bc775c94f011ecbc4bac1f6bc7bdc6","object":"Address","created_at":"2022-02-23T21:31:55+00:00","updated_at":"2022-02-23T21:31:55+00:00","name":"JACK
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_035748421a2846a4bd2ff181a0998928","object":"Parcel","created_at":"2022-04-11T18:34:48Z","updated_at":"2022-04-11T18:34:48Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":{"object":"PostageLabel","id":"pl_9d604a62b7974712a8f9ac31901b7a33","created_at":"2022-04-11T18:34:49Z","updated_at":"2022-04-11T18:34:49Z","date_advance":0,"integrated_form":"none","label_date":"2022-04-11T18:34:49Z","label_resolution":300,"label_size":"4x6","label_type":"default","label_file_type":"image/png","label_url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220411/03ca0d800e484defb56196a8b91b2a16.png","label_pdf_url":null,"label_zpl_url":null,"label_epl2_url":null,"label_file":null},"rates":[{"id":"rate_8a81ca44fcd943e188c6fe7fa5542010","object":"Rate","created_at":"2022-04-11T18:34:48Z","updated_at":"2022-04-11T18:34:48Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_238da2da32894d2396d8619b8e64f06d","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},{"id":"rate_6a897c1f622f46a9b5f6055307ecf3a4","object":"Rate","created_at":"2022-04-11T18:34:48Z","updated_at":"2022-04-11T18:34:48Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_238da2da32894d2396d8619b8e64f06d","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},{"id":"rate_e82dd84336d4402f8a567c9da1d8c536","object":"Rate","created_at":"2022-04-11T18:34:48Z","updated_at":"2022-04-11T18:34:48Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_238da2da32894d2396d8619b8e64f06d","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},{"id":"rate_b935cdf5c36f48c2bbb6eca780be9a80","object":"Rate","created_at":"2022-04-11T18:34:48Z","updated_at":"2022-04-11T18:34:48Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_238da2da32894d2396d8619b8e64f06d","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"}],"refund_status":null,"scan_form":null,"selected_rate":{"id":"rate_b935cdf5c36f48c2bbb6eca780be9a80","object":"Rate","created_at":"2022-04-11T18:34:49Z","updated_at":"2022-04-11T18:34:49Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_238da2da32894d2396d8619b8e64f06d","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},"tracker":{"id":"trk_b442d09741d84f93b371b09662b4b36b","object":"Tracker","mode":"test","tracking_code":"9400100109361114522120","status":"unknown","status_detail":"unknown","created_at":"2022-04-11T18:34:49Z","updated_at":"2022-04-11T18:34:49Z","signed_by":null,"weight":null,"est_delivery_date":null,"shipment_id":"shp_238da2da32894d2396d8619b8e64f06d","carrier":"USPS","tracking_details":[],"fees":[],"carrier_detail":null,"public_url":"https://track.easypost.com/djE6dHJrX2I0NDJkMDk3NDFkODRmOTNiMzcxYjA5NjYyYjRiMzZi"},"to_address":{"id":"adr_1169b2d5b9c611ec84e0ac1f6b0a0d1e","object":"Address","created_at":"2022-04-11T18:34:48+00:00","updated_at":"2022-04-11T18:34:49+00:00","name":"JACK
         SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN
-        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"usps_zone":1,"return_address":{"id":"adr_05be9e1b94f011eca969ac1f6bc7b362","object":"Address","created_at":"2022-02-23T21:31:55+00:00","updated_at":"2022-02-23T21:31:55+00:00","name":"Jack
+        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"usps_zone":1,"return_address":{"id":"adr_116b748cb9c611ec83d9ac1f6bc7b362","object":"Address","created_at":"2022-04-11T18:34:48+00:00","updated_at":"2022-04-11T18:34:48+00:00","name":"Jack
         Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_05bc775c94f011ecbc4bac1f6bc7bdc6","object":"Address","created_at":"2022-02-23T21:31:55+00:00","updated_at":"2022-02-23T21:31:55+00:00","name":"JACK
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_1169b2d5b9c611ec84e0ac1f6b0a0d1e","object":"Address","created_at":"2022-04-11T18:34:48+00:00","updated_at":"2022-04-11T18:34:49+00:00","name":"JACK
         SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN
-        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"forms":[],"fees":[{"object":"Fee","type":"LabelFee","amount":"0.01000","charged":true,"refunded":false},{"object":"Fee","type":"PostageFee","amount":"5.49000","charged":true,"refunded":false}],"id":"shp_40a7ab22b08e47d28fa8b400eb43fa14","object":"Shipment"}'
-  recorded_at: Wed, 23 Feb 2022 21:31:56 GMT
+        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"forms":[],"fees":[{"object":"Fee","type":"LabelFee","amount":"0.01000","charged":true,"refunded":false},{"object":"Fee","type":"PostageFee","amount":"5.49000","charged":true,"refunded":false}],"id":"shp_238da2da32894d2396d8619b8e64f06d","object":"Shipment"}'
+  recorded_at: Mon, 11 Apr 2022 18:34:49 GMT
 - request:
     method: post
     uri: https://api.easypost.com/v2/pickups
     body:
       encoding: UTF-8
       string: '{"pickup":{"address":{"name":"Jack Sparrow","company":"EasyPost","street1":"388
-        Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","phone":"5555555555"},"min_datetime":"2022-02-24","max_datetime":"2022-02-25","instructions":"Pickup
-        at front door","shipment":{"id":"shp_40a7ab22b08e47d28fa8b400eb43fa14"}}}'
+        Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","phone":"5555555555"},"min_datetime":"2022-04-12","max_datetime":"2022-04-12","instructions":"Pickup
+        at front door","shipment":{"id":"shp_238da2da32894d2396d8619b8e64f06d"}}}'
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
       User-Agent:
-      - EasyPost/v2 RubyClient/3.5.0 Ruby/3.1.0-p0
+      - EasyPost/v2 RubyClient/4.1.2 Ruby/3.1.1-p18
       Content-Type:
       - application/json
       Authorization: "<AUTHORIZATION>"
@@ -115,7 +113,7 @@ http_interactions:
       Referrer-Policy:
       - strict-origin-when-cross-origin
       X-Ep-Request-Uuid:
-      - 7b40663b6216a7cce788f7480041823c
+      - '0991fb55625474c9e786b40200232f22'
       Cache-Control:
       - no-cache, no-store
       Pragma:
@@ -125,34 +123,32 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"65507c5acac8d1f33a813b10db3132e2"
-      X-Request-Id:
-      - 5590ccbe-54b6-487e-817f-101ebfcaf8fc
+      - W/"b4c45b750bfd5539b9507a1fa7a937be"
       X-Runtime:
-      - '0.652562'
+      - '0.801241'
       Transfer-Encoding:
       - chunked
       X-Node:
-      - bigweb8nuq
+      - bigweb4nuq
       X-Version-Label:
-      - easypost-202202232103-87ed4a9d34-master
+      - easypost-202204082123-da17cc1ac2-master
       X-Backend:
       - easypost
       X-Proxied:
-      - extlb2nuq 88c34981dc
-      - intlb2nuq 88c34981dc
+      - extlb2nuq fde591f008
+      - intlb1nuq fde591f008
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"pickup_6609198ad2f04233800014dfc951d55a","object":"Pickup","created_at":"2022-02-23T21:31:56Z","updated_at":"2022-02-23T21:31:56Z","mode":"test","status":"unknown","reference":null,"min_datetime":"2022-02-24T00:00:00Z","max_datetime":"2022-02-25T00:00:00Z","is_account_address":false,"instructions":"Pickup
-        at front door","messages":[],"confirmation":null,"address":{"id":"adr_0674383294f011ec9f74ac1f6bc72124","object":"Address","created_at":"2022-02-23T21:31:56+00:00","updated_at":"2022-02-23T21:31:56+00:00","name":"Jack
+      string: '{"id":"pickup_d243ac138d9a4fb3af003169b70034be","object":"Pickup","created_at":"2022-04-11T18:34:50Z","updated_at":"2022-04-11T18:34:50Z","mode":"test","status":"unknown","reference":null,"min_datetime":"2022-04-12T00:00:00Z","max_datetime":"2022-04-12T00:00:00Z","is_account_address":false,"instructions":"Pickup
+        at front door","messages":[],"confirmation":null,"address":{"id":"adr_1215dea7b9c611ec9c6cac1f6bc72124","object":"Address","created_at":"2022-04-11T18:34:49+00:00","updated_at":"2022-04-11T18:34:49+00:00","name":"Jack
         Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"carrier_accounts":[],"pickup_rates":[{"mode":"test","service":"NextDay","rate":"0.00","currency":"USD","created_at":"2022-02-23T21:31:56Z","updated_at":"2022-02-23T21:31:56Z","carrier":"USPS","pickup_id":"pickup_6609198ad2f04233800014dfc951d55a","id":"pickuprate_74674913d6794f87b92469f8f410831c","object":"PickupRate"}]}'
-  recorded_at: Wed, 23 Feb 2022 21:31:56 GMT
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"carrier_accounts":[],"pickup_rates":[{"mode":"test","service":"NextDay","rate":"0.00","currency":"USD","created_at":"2022-04-11T18:34:50Z","updated_at":"2022-04-11T18:34:50Z","carrier":"USPS","pickup_id":"pickup_d243ac138d9a4fb3af003169b70034be","id":"pickuprate_5f8f61fc5598439d855d7f8a121aa65f","object":"PickupRate"}]}'
+  recorded_at: Mon, 11 Apr 2022 18:34:50 GMT
 - request:
     method: post
-    uri: https://api.easypost.com/v2/pickups/pickup_6609198ad2f04233800014dfc951d55a/buy
+    uri: https://api.easypost.com/v2/pickups/pickup_d243ac138d9a4fb3af003169b70034be/buy
     body:
       encoding: UTF-8
       string: '{"carrier":"USPS","service":"NextDay"}'
@@ -162,7 +158,7 @@ http_interactions:
       Accept:
       - "*/*"
       User-Agent:
-      - EasyPost/v2 RubyClient/3.5.0 Ruby/3.1.0-p0
+      - EasyPost/v2 RubyClient/4.1.2 Ruby/3.1.1-p18
       Content-Type:
       - application/json
       Authorization: "<AUTHORIZATION>"
@@ -184,7 +180,7 @@ http_interactions:
       Referrer-Policy:
       - strict-origin-when-cross-origin
       X-Ep-Request-Uuid:
-      - 7b4066376216a7cde788f7490041826c
+      - '0991fb55625474cae786b41a00232f85'
       Cache-Control:
       - no-cache, no-store
       Pragma:
@@ -194,34 +190,32 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"1f12bc37fe21926db4ccad86bb3bc3d0"
-      X-Request-Id:
-      - a76b1732-7bdc-4ff8-a006-b687b8c6f702
+      - W/"70a5c6df522e69135162170e1227b756"
       X-Runtime:
-      - '0.847477'
+      - '1.040029'
       Transfer-Encoding:
       - chunked
       X-Node:
       - bigweb3nuq
       X-Version-Label:
-      - easypost-202202232103-87ed4a9d34-master
+      - easypost-202204082123-da17cc1ac2-master
       X-Backend:
       - easypost
       X-Proxied:
-      - extlb2nuq 88c34981dc
-      - intlb1nuq 88c34981dc
+      - extlb2nuq fde591f008
+      - intlb2nuq fde591f008
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"pickup_6609198ad2f04233800014dfc951d55a","object":"Pickup","created_at":"2022-02-23T21:31:56Z","updated_at":"2022-02-23T21:31:57Z","mode":"test","status":"scheduled","reference":null,"min_datetime":"2022-02-24T00:00:00Z","max_datetime":"2022-02-25T00:00:00Z","is_account_address":false,"instructions":"Pickup
-        at front door","messages":[],"confirmation":"WTC61769224","address":{"id":"adr_0674383294f011ec9f74ac1f6bc72124","object":"Address","created_at":"2022-02-23T21:31:56+00:00","updated_at":"2022-02-23T21:31:56+00:00","name":"Jack
+      string: '{"id":"pickup_d243ac138d9a4fb3af003169b70034be","object":"Pickup","created_at":"2022-04-11T18:34:50Z","updated_at":"2022-04-11T18:34:51Z","mode":"test","status":"scheduled","reference":null,"min_datetime":"2022-04-12T00:00:00Z","max_datetime":"2022-04-12T00:00:00Z","is_account_address":false,"instructions":"Pickup
+        at front door","messages":[],"confirmation":"WTC61774818","address":{"id":"adr_1215dea7b9c611ec9c6cac1f6bc72124","object":"Address","created_at":"2022-04-11T18:34:49+00:00","updated_at":"2022-04-11T18:34:49+00:00","name":"Jack
         Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"carrier_accounts":[],"pickup_rates":[{"mode":"test","service":"NextDay","rate":"0.00","currency":"USD","created_at":"2022-02-23T21:31:56Z","updated_at":"2022-02-23T21:31:56Z","carrier":"USPS","pickup_id":"pickup_6609198ad2f04233800014dfc951d55a","id":"pickuprate_74674913d6794f87b92469f8f410831c","object":"PickupRate"}]}'
-  recorded_at: Wed, 23 Feb 2022 21:31:57 GMT
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"carrier_accounts":[],"pickup_rates":[{"mode":"test","service":"NextDay","rate":"0.00","currency":"USD","created_at":"2022-04-11T18:34:50Z","updated_at":"2022-04-11T18:34:50Z","carrier":"USPS","pickup_id":"pickup_d243ac138d9a4fb3af003169b70034be","id":"pickuprate_5f8f61fc5598439d855d7f8a121aa65f","object":"PickupRate"}]}'
+  recorded_at: Mon, 11 Apr 2022 18:34:51 GMT
 - request:
     method: post
-    uri: https://api.easypost.com/v2/pickups/pickup_6609198ad2f04233800014dfc951d55a/cancel
+    uri: https://api.easypost.com/v2/pickups/pickup_d243ac138d9a4fb3af003169b70034be/cancel
     body:
       encoding: UTF-8
       string: "{}"
@@ -231,7 +225,7 @@ http_interactions:
       Accept:
       - "*/*"
       User-Agent:
-      - EasyPost/v2 RubyClient/3.5.0 Ruby/3.1.0-p0
+      - EasyPost/v2 RubyClient/4.1.2 Ruby/3.1.1-p18
       Content-Type:
       - application/json
       Authorization: "<AUTHORIZATION>"
@@ -253,7 +247,7 @@ http_interactions:
       Referrer-Policy:
       - strict-origin-when-cross-origin
       X-Ep-Request-Uuid:
-      - 7b4066366216a7cee788f74a004182a8
+      - '0991fb54625474cce786b41b00232fed'
       Cache-Control:
       - no-cache, no-store
       Pragma:
@@ -263,29 +257,27 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"3a71038cdc97c5df626c53ba9b54f10c"
-      X-Request-Id:
-      - e2f3bf34-6753-4e4b-981c-4c9d7df01a5d
+      - W/"e859380b4f3d917d0d8aa5ca42605919"
       X-Runtime:
-      - '0.795878'
+      - '0.966242'
       Transfer-Encoding:
       - chunked
       X-Node:
       - bigweb9nuq
       X-Version-Label:
-      - easypost-202202232103-87ed4a9d34-master
+      - easypost-202204082123-da17cc1ac2-master
       X-Backend:
       - easypost
       X-Proxied:
-      - extlb2nuq 88c34981dc
-      - intlb1nuq 88c34981dc
+      - extlb2nuq fde591f008
+      - intlb1nuq fde591f008
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"pickup_6609198ad2f04233800014dfc951d55a","object":"Pickup","created_at":"2022-02-23T21:31:56Z","updated_at":"2022-02-23T21:31:58Z","mode":"test","status":"canceled","reference":null,"min_datetime":"2022-02-24T00:00:00Z","max_datetime":"2022-02-25T00:00:00Z","is_account_address":false,"instructions":"Pickup
-        at front door","messages":[],"confirmation":"WTC61769224","address":{"id":"adr_0674383294f011ec9f74ac1f6bc72124","object":"Address","created_at":"2022-02-23T21:31:56+00:00","updated_at":"2022-02-23T21:31:56+00:00","name":"Jack
+      string: '{"id":"pickup_d243ac138d9a4fb3af003169b70034be","object":"Pickup","created_at":"2022-04-11T18:34:50Z","updated_at":"2022-04-11T18:34:53Z","mode":"test","status":"canceled","reference":null,"min_datetime":"2022-04-12T00:00:00Z","max_datetime":"2022-04-12T00:00:00Z","is_account_address":false,"instructions":"Pickup
+        at front door","messages":[],"confirmation":"WTC61774818","address":{"id":"adr_1215dea7b9c611ec9c6cac1f6bc72124","object":"Address","created_at":"2022-04-11T18:34:49+00:00","updated_at":"2022-04-11T18:34:49+00:00","name":"Jack
         Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"carrier_accounts":[],"pickup_rates":[{"mode":"test","service":"NextDay","rate":"0.00","currency":"USD","created_at":"2022-02-23T21:31:56Z","updated_at":"2022-02-23T21:31:56Z","carrier":"USPS","pickup_id":"pickup_6609198ad2f04233800014dfc951d55a","id":"pickuprate_74674913d6794f87b92469f8f410831c","object":"PickupRate"}]}'
-  recorded_at: Wed, 23 Feb 2022 21:31:58 GMT
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"carrier_accounts":[],"pickup_rates":[{"mode":"test","service":"NextDay","rate":"0.00","currency":"USD","created_at":"2022-04-11T18:34:50Z","updated_at":"2022-04-11T18:34:50Z","carrier":"USPS","pickup_id":"pickup_d243ac138d9a4fb3af003169b70034be","id":"pickuprate_5f8f61fc5598439d855d7f8a121aa65f","object":"PickupRate"}]}'
+  recorded_at: Mon, 11 Apr 2022 18:34:53 GMT
 recorded_with: VCR 6.0.0

--- a/spec/cassettes/pickup/EasyPost_Pickup_create_creates_a_pickup.yml
+++ b/spec/cassettes/pickup/EasyPost_Pickup_create_creates_a_pickup.yml
@@ -37,7 +37,7 @@ http_interactions:
       Referrer-Policy:
       - strict-origin-when-cross-origin
       X-Ep-Request-Uuid:
-      - 44f9e901624f59d7e787c43900103dc7
+      - '0991fb57625474c0e786b3f900232b59'
       Cache-Control:
       - no-cache, no-store
       Pragma:
@@ -45,46 +45,46 @@ http_interactions:
       Expires:
       - '0'
       Location:
-      - "/api/v2/shipments/shp_ea372dbd40114ff7b3c34fa98bcbd708"
+      - "/api/v2/shipments/shp_e2b8ec8d75c34627b07312b9ee9960d5"
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"0d377f073a148ddf83d9b0bbd53d19f5"
+      - W/"05ac7b1b1d42187f551099c135e5eb3a"
       X-Runtime:
-      - '0.862867'
+      - '0.991916'
       Transfer-Encoding:
       - chunked
       X-Node:
-      - bigweb2nuq
+      - bigweb6nuq
       X-Version-Label:
-      - easypost-202204071939-d894f5743c-master
+      - easypost-202204082123-da17cc1ac2-master
       X-Backend:
       - easypost
       X-Proxied:
-      - extlb1nuq fde591f008
+      - extlb2nuq fde591f008
       - intlb1nuq fde591f008
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
     body:
       encoding: ASCII-8BIT
-      string: '{"created_at":"2022-04-07T21:38:31Z","is_return":false,"messages":[],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":"9400100109361114095150","updated_at":"2022-04-07T21:38:31Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_1181aee3b6bb11ec86abac1f6b0a0d1e","object":"Address","created_at":"2022-04-07T21:38:31+00:00","updated_at":"2022-04-07T21:38:31+00:00","name":"Jack
+      string: '{"created_at":"2022-04-11T18:34:40Z","is_return":false,"messages":[],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":"9400100109361114522090","updated_at":"2022-04-11T18:34:41Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_0c4dde30b9c611ec8319ac1f6b0a0d1e","object":"Address","created_at":"2022-04-11T18:34:40+00:00","updated_at":"2022-04-11T18:34:40+00:00","name":"Jack
         Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_2b32a5db263b4f6d8d7cc6eeb3760071","object":"Parcel","created_at":"2022-04-07T21:38:31Z","updated_at":"2022-04-07T21:38:31Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":{"object":"PostageLabel","id":"pl_a30c7e9234c9462bb1bb935257d44b4f","created_at":"2022-04-07T21:38:31Z","updated_at":"2022-04-07T21:38:31Z","date_advance":0,"integrated_form":"none","label_date":"2022-04-07T21:38:31Z","label_resolution":300,"label_size":"4x6","label_type":"default","label_file_type":"image/png","label_url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220407/6b573a4916274b70900a4b2fd350b7bc.png","label_pdf_url":null,"label_zpl_url":null,"label_epl2_url":null,"label_file":null},"rates":[{"id":"rate_41683267f39d44d8a5b457eb01a17b37","object":"Rate","created_at":"2022-04-07T21:38:31Z","updated_at":"2022-04-07T21:38:31Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_ea372dbd40114ff7b3c34fa98bcbd708","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},{"id":"rate_e88fbc92fd8745dc8fbad399d95f0e21","object":"Rate","created_at":"2022-04-07T21:38:31Z","updated_at":"2022-04-07T21:38:31Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_ea372dbd40114ff7b3c34fa98bcbd708","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},{"id":"rate_e4f1ca66aa104b2c943c3f522d5781eb","object":"Rate","created_at":"2022-04-07T21:38:31Z","updated_at":"2022-04-07T21:38:31Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_ea372dbd40114ff7b3c34fa98bcbd708","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},{"id":"rate_b30d8872a3bc4a309334014cf2077e11","object":"Rate","created_at":"2022-04-07T21:38:31Z","updated_at":"2022-04-07T21:38:31Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_ea372dbd40114ff7b3c34fa98bcbd708","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"}],"refund_status":null,"scan_form":null,"selected_rate":{"id":"rate_41683267f39d44d8a5b457eb01a17b37","object":"Rate","created_at":"2022-04-07T21:38:31Z","updated_at":"2022-04-07T21:38:31Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_ea372dbd40114ff7b3c34fa98bcbd708","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},"tracker":{"id":"trk_cb763ce9e2cf492d939b4b227cfde772","object":"Tracker","mode":"test","tracking_code":"9400100109361114095150","status":"unknown","status_detail":"unknown","created_at":"2022-04-07T21:38:31Z","updated_at":"2022-04-07T21:38:31Z","signed_by":null,"weight":null,"est_delivery_date":null,"shipment_id":"shp_ea372dbd40114ff7b3c34fa98bcbd708","carrier":"USPS","tracking_details":[],"fees":[],"carrier_detail":null,"public_url":"https://track.easypost.com/djE6dHJrX2NiNzYzY2U5ZTJjZjQ5MmQ5MzliNGIyMjdjZmRlNzcy"},"to_address":{"id":"adr_117fec70b6bb11ec9942ac1f6bc72124","object":"Address","created_at":"2022-04-07T21:38:31+00:00","updated_at":"2022-04-07T21:38:31+00:00","name":"JACK
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_b9d0a3eba89b490c81ee79a9dde47485","object":"Parcel","created_at":"2022-04-11T18:34:40Z","updated_at":"2022-04-11T18:34:40Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":{"object":"PostageLabel","id":"pl_26fa45fa12fa4eff903043b8192d0769","created_at":"2022-04-11T18:34:40Z","updated_at":"2022-04-11T18:34:41Z","date_advance":0,"integrated_form":"none","label_date":"2022-04-11T18:34:40Z","label_resolution":300,"label_size":"4x6","label_type":"default","label_file_type":"image/png","label_url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220411/641f0c67933e413fac9e057dbae05eac.png","label_pdf_url":null,"label_zpl_url":null,"label_epl2_url":null,"label_file":null},"rates":[{"id":"rate_511904cb02c94dcfa595ac64e318f8d4","object":"Rate","created_at":"2022-04-11T18:34:40Z","updated_at":"2022-04-11T18:34:40Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_e2b8ec8d75c34627b07312b9ee9960d5","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},{"id":"rate_928668d4b9d14bf683b18eef467c4a06","object":"Rate","created_at":"2022-04-11T18:34:40Z","updated_at":"2022-04-11T18:34:40Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_e2b8ec8d75c34627b07312b9ee9960d5","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},{"id":"rate_de14e74565434c44867401d38ade2633","object":"Rate","created_at":"2022-04-11T18:34:40Z","updated_at":"2022-04-11T18:34:40Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_e2b8ec8d75c34627b07312b9ee9960d5","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},{"id":"rate_1f0162e14d2d48d0a9eaf26d1c3fb691","object":"Rate","created_at":"2022-04-11T18:34:40Z","updated_at":"2022-04-11T18:34:40Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_e2b8ec8d75c34627b07312b9ee9960d5","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"}],"refund_status":null,"scan_form":null,"selected_rate":{"id":"rate_511904cb02c94dcfa595ac64e318f8d4","object":"Rate","created_at":"2022-04-11T18:34:40Z","updated_at":"2022-04-11T18:34:40Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_e2b8ec8d75c34627b07312b9ee9960d5","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},"tracker":{"id":"trk_43e805b6bb2b4086a561c42458c0f456","object":"Tracker","mode":"test","tracking_code":"9400100109361114522090","status":"unknown","status_detail":"unknown","created_at":"2022-04-11T18:34:41Z","updated_at":"2022-04-11T18:34:41Z","signed_by":null,"weight":null,"est_delivery_date":null,"shipment_id":"shp_e2b8ec8d75c34627b07312b9ee9960d5","carrier":"USPS","tracking_details":[],"fees":[],"carrier_detail":null,"public_url":"https://track.easypost.com/djE6dHJrXzQzZTgwNWI2YmIyYjQwODZhNTYxYzQyNDU4YzBmNDU2"},"to_address":{"id":"adr_0c4b65a9b9c611ec9a53ac1f6bc72124","object":"Address","created_at":"2022-04-11T18:34:40+00:00","updated_at":"2022-04-11T18:34:40+00:00","name":"JACK
         SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN
-        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"usps_zone":1,"return_address":{"id":"adr_1181aee3b6bb11ec86abac1f6b0a0d1e","object":"Address","created_at":"2022-04-07T21:38:31+00:00","updated_at":"2022-04-07T21:38:31+00:00","name":"Jack
+        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"usps_zone":1,"return_address":{"id":"adr_0c4dde30b9c611ec8319ac1f6b0a0d1e","object":"Address","created_at":"2022-04-11T18:34:40+00:00","updated_at":"2022-04-11T18:34:40+00:00","name":"Jack
         Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_117fec70b6bb11ec9942ac1f6bc72124","object":"Address","created_at":"2022-04-07T21:38:31+00:00","updated_at":"2022-04-07T21:38:31+00:00","name":"JACK
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_0c4b65a9b9c611ec9a53ac1f6bc72124","object":"Address","created_at":"2022-04-11T18:34:40+00:00","updated_at":"2022-04-11T18:34:40+00:00","name":"JACK
         SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN
-        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"forms":[],"fees":[{"object":"Fee","type":"LabelFee","amount":"0.01000","charged":true,"refunded":false},{"object":"Fee","type":"PostageFee","amount":"5.49000","charged":true,"refunded":false}],"id":"shp_ea372dbd40114ff7b3c34fa98bcbd708","object":"Shipment"}'
-  recorded_at: Thu, 07 Apr 2022 21:38:31 GMT
+        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"forms":[],"fees":[{"object":"Fee","type":"LabelFee","amount":"0.01000","charged":true,"refunded":false},{"object":"Fee","type":"PostageFee","amount":"5.49000","charged":true,"refunded":false}],"id":"shp_e2b8ec8d75c34627b07312b9ee9960d5","object":"Shipment"}'
+  recorded_at: Mon, 11 Apr 2022 18:34:41 GMT
 - request:
     method: post
     uri: https://api.easypost.com/v2/pickups
     body:
       encoding: UTF-8
       string: '{"pickup":{"address":{"name":"Jack Sparrow","company":"EasyPost","street1":"388
-        Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","phone":"5555555555"},"min_datetime":"2022-04-09","max_datetime":"2022-04-09","instructions":"Pickup
-        at front door","shipment":{"id":"shp_ea372dbd40114ff7b3c34fa98bcbd708"}}}'
+        Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","phone":"5555555555"},"min_datetime":"2022-04-12","max_datetime":"2022-04-12","instructions":"Pickup
+        at front door","shipment":{"id":"shp_e2b8ec8d75c34627b07312b9ee9960d5"}}}'
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -113,7 +113,7 @@ http_interactions:
       Referrer-Policy:
       - strict-origin-when-cross-origin
       X-Ep-Request-Uuid:
-      - 44f9e905624f59d8e787c43a00103e0e
+      - '0991fb57625474c1e786b3fa00232bce'
       Cache-Control:
       - no-cache, no-store
       Pragma:
@@ -123,27 +123,27 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"245dac48c6a981f64652b8655e5c9103"
+      - W/"0b6dfb407aacc8340782af876814ff3c"
       X-Runtime:
-      - '1.539821'
+      - '0.870326'
       Transfer-Encoding:
       - chunked
       X-Node:
-      - bigweb2nuq
+      - bigweb9nuq
       X-Version-Label:
-      - easypost-202204071939-d894f5743c-master
+      - easypost-202204082123-da17cc1ac2-master
       X-Backend:
       - easypost
       X-Proxied:
-      - extlb1nuq fde591f008
-      - intlb2nuq fde591f008
+      - extlb2nuq fde591f008
+      - intlb1nuq fde591f008
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"pickup_55f1bf1fc9c649b8a408c0a002b3ebf9","object":"Pickup","created_at":"2022-04-07T21:38:32Z","updated_at":"2022-04-07T21:38:32Z","mode":"test","status":"unknown","reference":null,"min_datetime":"2022-04-09T00:00:00Z","max_datetime":"2022-04-09T00:00:00Z","is_account_address":false,"instructions":"Pickup
-        at front door","messages":[],"confirmation":null,"address":{"id":"adr_1221b96cb6bb11ec86ceac1f6b0a0d1e","object":"Address","created_at":"2022-04-07T21:38:32+00:00","updated_at":"2022-04-07T21:38:32+00:00","name":"Jack
+      string: '{"id":"pickup_a6c46b72370f4fa4b26295dda0c5b551","object":"Pickup","created_at":"2022-04-11T18:34:41Z","updated_at":"2022-04-11T18:34:41Z","mode":"test","status":"unknown","reference":null,"min_datetime":"2022-04-12T00:00:00Z","max_datetime":"2022-04-12T00:00:00Z","is_account_address":false,"instructions":"Pickup
+        at front door","messages":[],"confirmation":null,"address":{"id":"adr_0cff0edab9c611ec8820ac1f6bc7bdc6","object":"Address","created_at":"2022-04-11T18:34:41+00:00","updated_at":"2022-04-11T18:34:41+00:00","name":"Jack
         Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"carrier_accounts":[],"pickup_rates":[{"mode":"test","service":"NextDay","rate":"0.00","currency":"USD","created_at":"2022-04-07T21:38:33Z","updated_at":"2022-04-07T21:38:33Z","carrier":"USPS","pickup_id":"pickup_55f1bf1fc9c649b8a408c0a002b3ebf9","id":"pickuprate_9383220828094b38a5ad711b090d1d8c","object":"PickupRate"}]}'
-  recorded_at: Thu, 07 Apr 2022 21:38:33 GMT
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"carrier_accounts":[],"pickup_rates":[{"mode":"test","service":"NextDay","rate":"0.00","currency":"USD","created_at":"2022-04-11T18:34:42Z","updated_at":"2022-04-11T18:34:42Z","carrier":"USPS","pickup_id":"pickup_a6c46b72370f4fa4b26295dda0c5b551","id":"pickuprate_f44de5d50bdc470b8c03f6be46646ab0","object":"PickupRate"}]}'
+  recorded_at: Mon, 11 Apr 2022 18:34:42 GMT
 recorded_with: VCR 6.0.0

--- a/spec/cassettes/pickup/EasyPost_Pickup_retrieve_retrieves_a_pickup.yml
+++ b/spec/cassettes/pickup/EasyPost_Pickup_retrieve_retrieves_a_pickup.yml
@@ -15,7 +15,7 @@ http_interactions:
       Accept:
       - "*/*"
       User-Agent:
-      - EasyPost/v2 RubyClient/3.5.0 Ruby/3.1.0-p0
+      - EasyPost/v2 RubyClient/4.1.2 Ruby/3.1.1-p18
       Content-Type:
       - application/json
       Authorization: "<AUTHORIZATION>"
@@ -37,7 +37,7 @@ http_interactions:
       Referrer-Policy:
       - strict-origin-when-cross-origin
       X-Ep-Request-Uuid:
-      - 7b40663a6216a7c5e788f72a0041806a
+      - '0991fb52625474c2e786b3fb00232c44'
       Cache-Control:
       - no-cache, no-store
       Pragma:
@@ -45,55 +45,55 @@ http_interactions:
       Expires:
       - '0'
       Location:
-      - "/api/v2/shipments/shp_aa4cfbc931c043829d2a0e42abb8408a"
+      - "/api/v2/shipments/shp_ba4dd2362746421fa08fdd684d462e0b"
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"592d7299369f5a38f74ff38b7768c0b0"
-      X-Request-Id:
-      - eea9ed0d-01c5-4f84-bf36-a2da2a8afb5e
+      - W/"70c5df7660c966c5ed8df3e08bc46de3"
       X-Runtime:
-      - '0.948564'
+      - '0.906490'
       Transfer-Encoding:
       - chunked
       X-Node:
-      - bigweb6nuq
+      - bigweb7nuq
       X-Version-Label:
-      - easypost-202202232103-87ed4a9d34-master
+      - easypost-202204082123-da17cc1ac2-master
       X-Backend:
       - easypost
+      X-Canary:
+      - direct
       X-Proxied:
-      - extlb2nuq 88c34981dc
-      - intlb1nuq 88c34981dc
+      - extlb2nuq fde591f008
+      - intlb2nuq fde591f008
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
     body:
       encoding: ASCII-8BIT
-      string: '{"created_at":"2022-02-23T21:31:49Z","is_return":false,"messages":[],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":"9400100895232108754356","updated_at":"2022-02-23T21:31:50Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_0258128594f011eca8a2ac1f6bc7b362","object":"Address","created_at":"2022-02-23T21:31:49+00:00","updated_at":"2022-02-23T21:31:49+00:00","name":"Jack
+      string: '{"created_at":"2022-04-11T18:34:42Z","is_return":false,"messages":[],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":"9400100109361114522106","updated_at":"2022-04-11T18:34:43Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_0dbd44c3b9c611ec8256ac1f6bc7b362","object":"Address","created_at":"2022-04-11T18:34:42+00:00","updated_at":"2022-04-11T18:34:42+00:00","name":"Jack
         Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_e0619bff72c9444b9ac6b9e09baca845","object":"Parcel","created_at":"2022-02-23T21:31:49Z","updated_at":"2022-02-23T21:31:49Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":{"object":"PostageLabel","id":"pl_fb80248ad9df4c5387cc55d9c07c8e39","created_at":"2022-02-23T21:31:49Z","updated_at":"2022-02-23T21:31:50Z","date_advance":0,"integrated_form":"none","label_date":"2022-02-23T21:31:49Z","label_resolution":300,"label_size":"4x6","label_type":"default","label_file_type":"image/png","label_url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220223/d25a11c392e2461dbb65b115681ac899.png","label_pdf_url":null,"label_zpl_url":null,"label_epl2_url":null,"label_file":null},"rates":[{"id":"rate_a6d93d6c1cf04475b159f98e50c7b80b","object":"Rate","created_at":"2022-02-23T21:31:49Z","updated_at":"2022-02-23T21:31:49Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_aa4cfbc931c043829d2a0e42abb8408a","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},{"id":"rate_00b99a0a0f534d40a299b1c2c000208c","object":"Rate","created_at":"2022-02-23T21:31:49Z","updated_at":"2022-02-23T21:31:49Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_aa4cfbc931c043829d2a0e42abb8408a","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},{"id":"rate_7c37c4d32b8f42aca398b050e6571e20","object":"Rate","created_at":"2022-02-23T21:31:49Z","updated_at":"2022-02-23T21:31:49Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_aa4cfbc931c043829d2a0e42abb8408a","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},{"id":"rate_b69d8b02c7744092b27d674e888d79a9","object":"Rate","created_at":"2022-02-23T21:31:49Z","updated_at":"2022-02-23T21:31:49Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_aa4cfbc931c043829d2a0e42abb8408a","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"}],"refund_status":null,"scan_form":null,"selected_rate":{"id":"rate_b69d8b02c7744092b27d674e888d79a9","object":"Rate","created_at":"2022-02-23T21:31:49Z","updated_at":"2022-02-23T21:31:49Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_aa4cfbc931c043829d2a0e42abb8408a","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},"tracker":{"id":"trk_05baeb75123a495aa57bc915246c18b5","object":"Tracker","mode":"test","tracking_code":"9400100895232108754356","status":"unknown","status_detail":"unknown","created_at":"2022-02-23T21:31:50Z","updated_at":"2022-02-23T21:31:50Z","signed_by":null,"weight":null,"est_delivery_date":null,"shipment_id":"shp_aa4cfbc931c043829d2a0e42abb8408a","carrier":"USPS","tracking_details":[],"fees":[],"carrier_detail":null,"public_url":"https://track.easypost.com/djE6dHJrXzA1YmFlYjc1MTIzYTQ5NWFhNTdiYzkxNTI0NmMxOGI1"},"to_address":{"id":"adr_0256222b94f011eca8a1ac1f6bc7b362","object":"Address","created_at":"2022-02-23T21:31:49+00:00","updated_at":"2022-02-23T21:31:49+00:00","name":"JACK
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_38365319ab524dc4b28dedcbed36fe1a","object":"Parcel","created_at":"2022-04-11T18:34:42Z","updated_at":"2022-04-11T18:34:42Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":{"object":"PostageLabel","id":"pl_ba63f124ccbd4a8a96d2743362c9c823","created_at":"2022-04-11T18:34:43Z","updated_at":"2022-04-11T18:34:43Z","date_advance":0,"integrated_form":"none","label_date":"2022-04-11T18:34:43Z","label_resolution":300,"label_size":"4x6","label_type":"default","label_file_type":"image/png","label_url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220411/54581279a142444b9eb598f998064bf1.png","label_pdf_url":null,"label_zpl_url":null,"label_epl2_url":null,"label_file":null},"rates":[{"id":"rate_16f77c6decc04cc69be1e354d35a5fda","object":"Rate","created_at":"2022-04-11T18:34:42Z","updated_at":"2022-04-11T18:34:42Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_ba4dd2362746421fa08fdd684d462e0b","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},{"id":"rate_2bbcaedfeb4f42e785cd5a9db02d5af0","object":"Rate","created_at":"2022-04-11T18:34:42Z","updated_at":"2022-04-11T18:34:42Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_ba4dd2362746421fa08fdd684d462e0b","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},{"id":"rate_3e7caa16334b4170931e679a17b115de","object":"Rate","created_at":"2022-04-11T18:34:42Z","updated_at":"2022-04-11T18:34:42Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_ba4dd2362746421fa08fdd684d462e0b","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},{"id":"rate_a761af27158a4960ac498402c2fd21b2","object":"Rate","created_at":"2022-04-11T18:34:42Z","updated_at":"2022-04-11T18:34:42Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_ba4dd2362746421fa08fdd684d462e0b","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"}],"refund_status":null,"scan_form":null,"selected_rate":{"id":"rate_2bbcaedfeb4f42e785cd5a9db02d5af0","object":"Rate","created_at":"2022-04-11T18:34:43Z","updated_at":"2022-04-11T18:34:43Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_ba4dd2362746421fa08fdd684d462e0b","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},"tracker":{"id":"trk_2de7f823ba30498bae1b98db2686ca43","object":"Tracker","mode":"test","tracking_code":"9400100109361114522106","status":"unknown","status_detail":"unknown","created_at":"2022-04-11T18:34:43Z","updated_at":"2022-04-11T18:34:43Z","signed_by":null,"weight":null,"est_delivery_date":null,"shipment_id":"shp_ba4dd2362746421fa08fdd684d462e0b","carrier":"USPS","tracking_details":[],"fees":[],"carrier_detail":null,"public_url":"https://track.easypost.com/djE6dHJrXzJkZTdmODIzYmEzMDQ5OGJhZTFiOThkYjI2ODZjYTQz"},"to_address":{"id":"adr_0dbb97e2b9c611ec8254ac1f6bc7b362","object":"Address","created_at":"2022-04-11T18:34:42+00:00","updated_at":"2022-04-11T18:34:42+00:00","name":"JACK
         SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN
-        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"usps_zone":1,"return_address":{"id":"adr_0258128594f011eca8a2ac1f6bc7b362","object":"Address","created_at":"2022-02-23T21:31:49+00:00","updated_at":"2022-02-23T21:31:49+00:00","name":"Jack
+        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"usps_zone":1,"return_address":{"id":"adr_0dbd44c3b9c611ec8256ac1f6bc7b362","object":"Address","created_at":"2022-04-11T18:34:42+00:00","updated_at":"2022-04-11T18:34:42+00:00","name":"Jack
         Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_0256222b94f011eca8a1ac1f6bc7b362","object":"Address","created_at":"2022-02-23T21:31:49+00:00","updated_at":"2022-02-23T21:31:49+00:00","name":"JACK
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_0dbb97e2b9c611ec8254ac1f6bc7b362","object":"Address","created_at":"2022-04-11T18:34:42+00:00","updated_at":"2022-04-11T18:34:42+00:00","name":"JACK
         SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN
-        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"forms":[],"fees":[{"object":"Fee","type":"LabelFee","amount":"0.01000","charged":true,"refunded":false},{"object":"Fee","type":"PostageFee","amount":"5.49000","charged":true,"refunded":false}],"id":"shp_aa4cfbc931c043829d2a0e42abb8408a","object":"Shipment"}'
-  recorded_at: Wed, 23 Feb 2022 21:31:50 GMT
+        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"forms":[],"fees":[{"object":"Fee","type":"LabelFee","amount":"0.01000","charged":true,"refunded":false},{"object":"Fee","type":"PostageFee","amount":"5.49000","charged":true,"refunded":false}],"id":"shp_ba4dd2362746421fa08fdd684d462e0b","object":"Shipment"}'
+  recorded_at: Mon, 11 Apr 2022 18:34:43 GMT
 - request:
     method: post
     uri: https://api.easypost.com/v2/pickups
     body:
       encoding: UTF-8
       string: '{"pickup":{"address":{"name":"Jack Sparrow","company":"EasyPost","street1":"388
-        Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","phone":"5555555555"},"min_datetime":"2022-02-24","max_datetime":"2022-02-25","instructions":"Pickup
-        at front door","shipment":{"id":"shp_aa4cfbc931c043829d2a0e42abb8408a"}}}'
+        Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","phone":"5555555555"},"min_datetime":"2022-04-12","max_datetime":"2022-04-12","instructions":"Pickup
+        at front door","shipment":{"id":"shp_ba4dd2362746421fa08fdd684d462e0b"}}}'
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
       User-Agent:
-      - EasyPost/v2 RubyClient/3.5.0 Ruby/3.1.0-p0
+      - EasyPost/v2 RubyClient/4.1.2 Ruby/3.1.1-p18
       Content-Type:
       - application/json
       Authorization: "<AUTHORIZATION>"
@@ -115,7 +115,7 @@ http_interactions:
       Referrer-Policy:
       - strict-origin-when-cross-origin
       X-Ep-Request-Uuid:
-      - 7b4066366216a7c6e788f72b004180bc
+      - '0991fb55625474c3e786b3fc00232ce3'
       Cache-Control:
       - no-cache, no-store
       Pragma:
@@ -125,34 +125,32 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"e2fbe7b3bed4c28b22f175f7f9d4d099"
-      X-Request-Id:
-      - 7f9b1421-21c1-4451-8247-774572acabbf
+      - W/"d6555a3dfb2b69827eb36e9bf1b3c6db"
       X-Runtime:
-      - '0.683288'
+      - '1.010372'
       Transfer-Encoding:
       - chunked
       X-Node:
-      - bigweb1nuq
+      - bigweb3nuq
       X-Version-Label:
-      - easypost-202202232103-87ed4a9d34-master
+      - easypost-202204082123-da17cc1ac2-master
       X-Backend:
       - easypost
       X-Proxied:
-      - extlb2nuq 88c34981dc
-      - intlb2nuq 88c34981dc
+      - extlb2nuq fde591f008
+      - intlb1nuq fde591f008
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"pickup_53098536771d47df866e965c635ad675","object":"Pickup","created_at":"2022-02-23T21:31:50Z","updated_at":"2022-02-23T21:31:50Z","mode":"test","status":"unknown","reference":null,"min_datetime":"2022-02-24T00:00:00Z","max_datetime":"2022-02-25T00:00:00Z","is_account_address":false,"instructions":"Pickup
-        at front door","messages":[],"confirmation":null,"address":{"id":"adr_0301996594f011eca8ceac1f6bc7b362","object":"Address","created_at":"2022-02-23T21:31:50+00:00","updated_at":"2022-02-23T21:31:50+00:00","name":"Jack
+      string: '{"id":"pickup_80b72d338fb24b9faa382ffabb645033","object":"Pickup","created_at":"2022-04-11T18:34:43Z","updated_at":"2022-04-11T18:34:43Z","mode":"test","status":"unknown","reference":null,"min_datetime":"2022-04-12T00:00:00Z","max_datetime":"2022-04-12T00:00:00Z","is_account_address":false,"instructions":"Pickup
+        at front door","messages":[],"confirmation":null,"address":{"id":"adr_0e63d529b9c611ec8295ac1f6bc7b362","object":"Address","created_at":"2022-04-11T18:34:43+00:00","updated_at":"2022-04-11T18:34:43+00:00","name":"Jack
         Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"carrier_accounts":[],"pickup_rates":[{"mode":"test","service":"NextDay","rate":"0.00","currency":"USD","created_at":"2022-02-23T21:31:51Z","updated_at":"2022-02-23T21:31:51Z","carrier":"USPS","pickup_id":"pickup_53098536771d47df866e965c635ad675","id":"pickuprate_8e9c0cc60f3d44979c31bce0e2dfed98","object":"PickupRate"}]}'
-  recorded_at: Wed, 23 Feb 2022 21:31:51 GMT
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"carrier_accounts":[],"pickup_rates":[{"mode":"test","service":"NextDay","rate":"0.00","currency":"USD","created_at":"2022-04-11T18:34:44Z","updated_at":"2022-04-11T18:34:44Z","carrier":"USPS","pickup_id":"pickup_80b72d338fb24b9faa382ffabb645033","id":"pickuprate_cd1043d803d5450484ba46102f168f2b","object":"PickupRate"}]}'
+  recorded_at: Mon, 11 Apr 2022 18:34:44 GMT
 - request:
     method: get
-    uri: https://api.easypost.com/v2/pickups/pickup_53098536771d47df866e965c635ad675
+    uri: https://api.easypost.com/v2/pickups/pickup_80b72d338fb24b9faa382ffabb645033
     body:
       encoding: US-ASCII
       string: ''
@@ -162,7 +160,7 @@ http_interactions:
       Accept:
       - "*/*"
       User-Agent:
-      - EasyPost/v2 RubyClient/3.5.0 Ruby/3.1.0-p0
+      - EasyPost/v2 RubyClient/4.1.2 Ruby/3.1.1-p18
       Content-Type:
       - application/json
       Authorization: "<AUTHORIZATION>"
@@ -184,7 +182,7 @@ http_interactions:
       Referrer-Policy:
       - strict-origin-when-cross-origin
       X-Ep-Request-Uuid:
-      - 7b4066376216a7c7e788f72c004180ef
+      - '0991fb57625474c4e786b3fd00232d62'
       Cache-Control:
       - no-cache, no-store
       Pragma:
@@ -194,29 +192,27 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"e2fbe7b3bed4c28b22f175f7f9d4d099"
-      X-Request-Id:
-      - 073bdccd-9ae4-4afb-8496-8d88fc378cba
+      - W/"d6555a3dfb2b69827eb36e9bf1b3c6db"
       X-Runtime:
-      - '0.075038'
+      - '0.087458'
       Transfer-Encoding:
       - chunked
       X-Node:
-      - bigweb4nuq
+      - bigweb8nuq
       X-Version-Label:
-      - easypost-202202232103-87ed4a9d34-master
+      - easypost-202204082123-da17cc1ac2-master
       X-Backend:
       - easypost
       X-Proxied:
-      - extlb2nuq 88c34981dc
-      - intlb1nuq 88c34981dc
+      - extlb2nuq fde591f008
+      - intlb2nuq fde591f008
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"pickup_53098536771d47df866e965c635ad675","object":"Pickup","created_at":"2022-02-23T21:31:50Z","updated_at":"2022-02-23T21:31:50Z","mode":"test","status":"unknown","reference":null,"min_datetime":"2022-02-24T00:00:00Z","max_datetime":"2022-02-25T00:00:00Z","is_account_address":false,"instructions":"Pickup
-        at front door","messages":[],"confirmation":null,"address":{"id":"adr_0301996594f011eca8ceac1f6bc7b362","object":"Address","created_at":"2022-02-23T21:31:50+00:00","updated_at":"2022-02-23T21:31:50+00:00","name":"Jack
+      string: '{"id":"pickup_80b72d338fb24b9faa382ffabb645033","object":"Pickup","created_at":"2022-04-11T18:34:43Z","updated_at":"2022-04-11T18:34:43Z","mode":"test","status":"unknown","reference":null,"min_datetime":"2022-04-12T00:00:00Z","max_datetime":"2022-04-12T00:00:00Z","is_account_address":false,"instructions":"Pickup
+        at front door","messages":[],"confirmation":null,"address":{"id":"adr_0e63d529b9c611ec8295ac1f6bc7b362","object":"Address","created_at":"2022-04-11T18:34:43+00:00","updated_at":"2022-04-11T18:34:43+00:00","name":"Jack
         Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"carrier_accounts":[],"pickup_rates":[{"mode":"test","service":"NextDay","rate":"0.00","currency":"USD","created_at":"2022-02-23T21:31:51Z","updated_at":"2022-02-23T21:31:51Z","carrier":"USPS","pickup_id":"pickup_53098536771d47df866e965c635ad675","id":"pickuprate_8e9c0cc60f3d44979c31bce0e2dfed98","object":"PickupRate"}]}'
-  recorded_at: Wed, 23 Feb 2022 21:31:51 GMT
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"carrier_accounts":[],"pickup_rates":[{"mode":"test","service":"NextDay","rate":"0.00","currency":"USD","created_at":"2022-04-11T18:34:44Z","updated_at":"2022-04-11T18:34:44Z","carrier":"USPS","pickup_id":"pickup_80b72d338fb24b9faa382ffabb645033","id":"pickuprate_cd1043d803d5450484ba46102f168f2b","object":"PickupRate"}]}'
+  recorded_at: Mon, 11 Apr 2022 18:34:45 GMT
 recorded_with: VCR 6.0.0

--- a/spec/cassettes/report/EasyPost_Report_all_retrieves_all_reports.yml
+++ b/spec/cassettes/report/EasyPost_Report_all_retrieves_all_reports.yml
@@ -12,7 +12,7 @@ http_interactions:
       Accept:
       - "*/*"
       User-Agent:
-      - EasyPost/v2 RubyClient/3.5.0 Ruby/3.1.0-p0
+      - EasyPost/v2 RubyClient/4.1.2 Ruby/3.1.1-p18
       Content-Type:
       - application/json
       Authorization: "<AUTHORIZATION>"
@@ -34,7 +34,7 @@ http_interactions:
       Referrer-Policy:
       - strict-origin-when-cross-origin
       X-Ep-Request-Uuid:
-      - 704d1f6f6218138ee78bafcb00530f2c
+      - '0991fb56625474cee786b421002330ce'
       Cache-Control:
       - no-cache, no-store
       Pragma:
@@ -44,26 +44,24 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"60f20c5a9c8d1d8dbe46e8fb621ffbbd"
-      X-Request-Id:
-      - 52f3ef08-49cf-4ee0-8ad1-f1d2d29502e9
+      - W/"833ba88e9d2922fe9f99f38ad755b703"
       X-Runtime:
-      - '0.038027'
+      - '0.098671'
       Transfer-Encoding:
       - chunked
       X-Node:
       - bigweb9nuq
       X-Version-Label:
-      - easypost-202202242013-00973e8608-master
+      - easypost-202204082123-da17cc1ac2-master
       X-Backend:
       - easypost
       X-Proxied:
-      - extlb2nuq 88c34981dc
-      - intlb2nuq 88c34981dc
+      - extlb2nuq fde591f008
+      - intlb2nuq fde591f008
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
     body:
       encoding: ASCII-8BIT
-      string: '{"reports":[{"id":"shprep_c1c292290ee6438785d23c6cacd3b879","object":"ShipmentReport","created_at":"2022-02-24T23:23:56Z","updated_at":"2022-02-24T23:23:57Z","start_date":"2022-02-21","end_date":"2022-02-23","mode":"test","status":"empty","url":null,"url_expires_at":null,"include_children":false},{"id":"shprep_4fa47ca0ecbd4322be81975f2b9bfea2","object":"ShipmentReport","created_at":"2022-02-24T23:23:55Z","updated_at":"2022-02-24T23:23:55Z","start_date":"2022-02-21","end_date":"2022-02-23","mode":"test","status":"empty","url":null,"url_expires_at":null,"include_children":false},{"id":"shprep_3340200ca0ad402e9fea7fe2aede2306","object":"ShipmentReport","created_at":"2022-02-07T17:52:49Z","updated_at":"2022-02-07T17:52:50Z","start_date":"2022-02-01","end_date":"2022-02-03","mode":"test","status":"available","url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/shipment_report/20220207/1ea9ced7b7f04d2b83ed253d8f0e8397.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAY27LO6YQVHEFDONM%2F20220224%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220224T232358Z&X-Amz-Expires=30&X-Amz-SignedHeaders=host&X-Amz-Signature=1c2ef0dae19c4520311942082b011c23c13a7a2d4e26e5190abe63ce9b6f9312","url_expires_at":"2022-02-24T23:24:28Z","include_children":false},{"id":"shprep_9f9d7c1b54964a22a73f721e22645a67","object":"ShipmentReport","created_at":"2022-02-07T17:51:49Z","updated_at":"2022-02-07T17:51:49Z","start_date":"2022-02-01","end_date":"2022-02-03","mode":"test","status":"available","url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/shipment_report/20220207/e845ffb403c84137ae4cf5e5ff6c92ca.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAY27LO6YQVHEFDONM%2F20220224%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220224T232358Z&X-Amz-Expires=30&X-Amz-SignedHeaders=host&X-Amz-Signature=c3c216ca6a60f631a85f70b76b73aa1ffc864b9ef7756caa8918f6df65046641","url_expires_at":"2022-02-24T23:24:28Z","include_children":false},{"id":"shprep_19e0fdaf21cd415f836d2be5663ab8a7","object":"ShipmentReport","created_at":"2022-02-05T00:20:54Z","updated_at":"2022-02-05T00:20:54Z","start_date":"2022-02-01","end_date":"2022-02-03","mode":"test","status":"available","url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/shipment_report/20220205/7ef70c1feb1b4dc1a046f41bb91f13d7.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAY27LO6YQVHEFDONM%2F20220224%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220224T232358Z&X-Amz-Expires=30&X-Amz-SignedHeaders=host&X-Amz-Signature=1dd83dcb97c68adb2f482d3ff94723eb422c31d97bef8a2e80c96cc5764c5a5a","url_expires_at":"2022-02-24T23:24:28Z","include_children":false}],"has_more":true}'
-  recorded_at: Thu, 24 Feb 2022 23:23:58 GMT
+      string: '{"reports":[{"id":"shprep_4b4e0861f4f244f4b9ffa21f7c329a2e","object":"ShipmentReport","created_at":"2022-04-11T18:34:54Z","updated_at":"2022-04-11T18:34:54Z","start_date":"2022-04-11","end_date":"2022-04-11","mode":"test","status":"new","url":null,"url_expires_at":null,"include_children":false},{"id":"shprep_43dbbe112f824bea942287f60b2cd1f9","object":"ShipmentReport","created_at":"2022-04-11T18:34:53Z","updated_at":"2022-04-11T18:34:54Z","start_date":"2022-04-11","end_date":"2022-04-11","mode":"test","status":"available","url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/shipment_report/20220411/b6336f93f770461b8c799fca2cf1f3cb.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAY27LO6YQS5SPYTWI%2F20220411%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220411T183454Z&X-Amz-Expires=30&X-Amz-SignedHeaders=host&X-Amz-Signature=922e20bca7944dcc68ef87453e3982b828de1cb1c1b7a0cf42056192c5aa69d0","url_expires_at":"2022-04-11T18:35:24Z","include_children":false},{"id":"shprep_d91ad7867567447886e0785b7de4bfbe","object":"ShipmentReport","created_at":"2022-04-11T18:34:53Z","updated_at":"2022-04-11T18:34:53Z","start_date":"2022-04-11","end_date":"2022-04-11","mode":"test","status":"available","url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/shipment_report/20220411/a40d806d7bfb486e802a6c89de06d371.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAY27LO6YQS5SPYTWI%2F20220411%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220411T183454Z&X-Amz-Expires=30&X-Amz-SignedHeaders=host&X-Amz-Signature=d9bedb8d3391ac819d71079954418f0dab568686fc3480c87bca6762f720b963","url_expires_at":"2022-04-11T18:35:24Z","include_children":false},{"id":"shprep_5674d6fc055c42c29b36db16a90e80c4","object":"ShipmentReport","created_at":"2022-04-11T18:34:53Z","updated_at":"2022-04-11T18:34:53Z","start_date":"2022-04-11","end_date":"2022-04-11","mode":"test","status":"available","url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/shipment_report/20220411/8c89ebb8192b4449958bdeb2eae88605.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAY27LO6YQS5SPYTWI%2F20220411%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220411T183454Z&X-Amz-Expires=30&X-Amz-SignedHeaders=host&X-Amz-Signature=24c9bc5bc376dedaa5b363df36a91c227541994b2ddd706fd9e20dee2f3b5ac2","url_expires_at":"2022-04-11T18:35:24Z","include_children":false},{"id":"shprep_b5444a78e9ac4edba7ff19b95bc40eee","object":"ShipmentReport","created_at":"2022-04-07T21:24:41Z","updated_at":"2022-04-07T21:24:41Z","start_date":"2022-04-05","end_date":"2022-04-07","mode":"test","status":"empty","url":null,"url_expires_at":null,"include_children":false}],"has_more":true}'
+  recorded_at: Mon, 11 Apr 2022 18:34:54 GMT
 recorded_with: VCR 6.0.0

--- a/spec/cassettes/report/EasyPost_Report_create_creates_a_report.yml
+++ b/spec/cassettes/report/EasyPost_Report_create_creates_a_report.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://api.easypost.com/v2/reports/shipment
     body:
       encoding: UTF-8
-      string: '{"start_date":"2022-04-05","end_date":"2022-04-07","type":"shipment"}'
+      string: '{"start_date":"2022-04-11","end_date":"2022-04-11","type":"shipment"}'
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -34,7 +34,7 @@ http_interactions:
       Referrer-Policy:
       - strict-origin-when-cross-origin
       X-Ep-Request-Uuid:
-      - 44f9e902624f5673e787bff9000f0fcd
+      - '0991fb54625474cde786b41c0023305b'
       Cache-Control:
       - no-cache, no-store
       Pragma:
@@ -44,24 +44,24 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"efdb2d41b82dee032f83160bc511ebfd"
+      - W/"5412ebeaa4172f8a41290ccf4b8b6d2f"
       X-Runtime:
-      - '0.048057'
+      - '0.031288'
       Transfer-Encoding:
       - chunked
       X-Node:
       - bigweb5nuq
       X-Version-Label:
-      - easypost-202204071939-d894f5743c-master
+      - easypost-202204082123-da17cc1ac2-master
       X-Backend:
       - easypost
       X-Proxied:
-      - extlb1nuq fde591f008
-      - intlb1nuq fde591f008
+      - extlb2nuq fde591f008
+      - intlb2nuq fde591f008
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"shprep_c73f9996ba5c4fe5a4e816062a8eb95b","object":"ShipmentReport","created_at":"2022-04-07T21:24:03Z","updated_at":"2022-04-07T21:24:03Z","start_date":"2022-04-05","end_date":"2022-04-07","mode":"test","status":"new","url":null,"url_expires_at":null,"include_children":false}'
-  recorded_at: Thu, 07 Apr 2022 21:24:03 GMT
+      string: '{"id":"shprep_5674d6fc055c42c29b36db16a90e80c4","object":"ShipmentReport","created_at":"2022-04-11T18:34:53Z","updated_at":"2022-04-11T18:34:53Z","start_date":"2022-04-11","end_date":"2022-04-11","mode":"test","status":"new","url":null,"url_expires_at":null,"include_children":false}'
+  recorded_at: Mon, 11 Apr 2022 18:34:53 GMT
 recorded_with: VCR 6.0.0

--- a/spec/cassettes/report/EasyPost_Report_create_creates_a_report_with_custom_additional_columns.yml
+++ b/spec/cassettes/report/EasyPost_Report_create_creates_a_report_with_custom_additional_columns.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://api.easypost.com/v2/reports/shipment
     body:
       encoding: UTF-8
-      string: '{"start_date":"2022-04-05","end_date":"2022-04-07","type":"shipment","additional_columns":["from_name","from_company"]}'
+      string: '{"start_date":"2022-04-11","end_date":"2022-04-11","type":"shipment","additional_columns":["from_name","from_company"]}'
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -34,7 +34,7 @@ http_interactions:
       Referrer-Policy:
       - strict-origin-when-cross-origin
       X-Ep-Request-Uuid:
-      - 44f9e904624f5699e787bffd000f1e8a
+      - '0991fb50625474cde786b41e00233090'
       Cache-Control:
       - no-cache, no-store
       Pragma:
@@ -44,24 +44,24 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"35e4073c86b1da29479ebe1da8ef4237"
+      - W/"6cc2c313c1dd69b2547e5aeb1151d1dd"
       X-Runtime:
-      - '0.035944'
+      - '0.045841'
       Transfer-Encoding:
       - chunked
       X-Node:
-      - bigweb4nuq
+      - bigweb9nuq
       X-Version-Label:
-      - easypost-202204071939-d894f5743c-master
+      - easypost-202204082123-da17cc1ac2-master
       X-Backend:
       - easypost
       X-Proxied:
-      - extlb1nuq fde591f008
-      - intlb2nuq fde591f008
+      - extlb2nuq fde591f008
+      - intlb1nuq fde591f008
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"shprep_b5444a78e9ac4edba7ff19b95bc40eee","object":"ShipmentReport","created_at":"2022-04-07T21:24:41Z","updated_at":"2022-04-07T21:24:41Z","start_date":"2022-04-05","end_date":"2022-04-07","mode":"test","status":"new","url":null,"url_expires_at":null,"include_children":false}'
-  recorded_at: Thu, 07 Apr 2022 21:24:41 GMT
+      string: '{"id":"shprep_43dbbe112f824bea942287f60b2cd1f9","object":"ShipmentReport","created_at":"2022-04-11T18:34:53Z","updated_at":"2022-04-11T18:34:53Z","start_date":"2022-04-11","end_date":"2022-04-11","mode":"test","status":"new","url":null,"url_expires_at":null,"include_children":false}'
+  recorded_at: Mon, 11 Apr 2022 18:34:53 GMT
 recorded_with: VCR 6.0.0

--- a/spec/cassettes/report/EasyPost_Report_create_creates_a_report_with_custom_columns.yml
+++ b/spec/cassettes/report/EasyPost_Report_create_creates_a_report_with_custom_columns.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://api.easypost.com/v2/reports/shipment
     body:
       encoding: UTF-8
-      string: '{"start_date":"2022-04-05","end_date":"2022-04-07","type":"shipment","columns":["usps_zone"]}'
+      string: '{"start_date":"2022-04-11","end_date":"2022-04-11","type":"shipment","columns":["usps_zone"]}'
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -34,7 +34,7 @@ http_interactions:
       Referrer-Policy:
       - strict-origin-when-cross-origin
       X-Ep-Request-Uuid:
-      - 44f9e8ff624f5699e787bffc000f1e64
+      - '0991fb57625474cde786b41d00233076'
       Cache-Control:
       - no-cache, no-store
       Pragma:
@@ -44,24 +44,24 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"e464ad4af95856a7e6f41d232ee54c84"
+      - W/"1b6a08e8b602a94a264c570617600188"
       X-Runtime:
-      - '0.039221'
+      - '0.049766'
       Transfer-Encoding:
       - chunked
       X-Node:
-      - bigweb3nuq
+      - bigweb1nuq
       X-Version-Label:
-      - easypost-202204071939-d894f5743c-master
+      - easypost-202204082123-da17cc1ac2-master
       X-Backend:
       - easypost
       X-Proxied:
-      - extlb1nuq fde591f008
-      - intlb2nuq fde591f008
+      - extlb2nuq fde591f008
+      - intlb1nuq fde591f008
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"shprep_cceb1dd34bd2473ca7e6b2fd752a72ba","object":"ShipmentReport","created_at":"2022-04-07T21:24:41Z","updated_at":"2022-04-07T21:24:41Z","start_date":"2022-04-05","end_date":"2022-04-07","mode":"test","status":"new","url":null,"url_expires_at":null,"include_children":false}'
-  recorded_at: Thu, 07 Apr 2022 21:24:41 GMT
+      string: '{"id":"shprep_d91ad7867567447886e0785b7de4bfbe","object":"ShipmentReport","created_at":"2022-04-11T18:34:53Z","updated_at":"2022-04-11T18:34:53Z","start_date":"2022-04-11","end_date":"2022-04-11","mode":"test","status":"new","url":null,"url_expires_at":null,"include_children":false}'
+  recorded_at: Mon, 11 Apr 2022 18:34:53 GMT
 recorded_with: VCR 6.0.0

--- a/spec/cassettes/report/EasyPost_Report_retrieve_retrieves_a_report.yml
+++ b/spec/cassettes/report/EasyPost_Report_retrieve_retrieves_a_report.yml
@@ -5,14 +5,14 @@ http_interactions:
     uri: https://api.easypost.com/v2/reports/shipment
     body:
       encoding: UTF-8
-      string: '{"start_date":"2022-02-21","end_date":"2022-02-23","type":"shipment"}'
+      string: '{"start_date":"2022-04-11","end_date":"2022-04-11","type":"shipment"}'
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
       User-Agent:
-      - EasyPost/v2 RubyClient/3.5.0 Ruby/3.1.0-p0
+      - EasyPost/v2 RubyClient/4.1.2 Ruby/3.1.1-p18
       Content-Type:
       - application/json
       Authorization: "<AUTHORIZATION>"
@@ -34,7 +34,7 @@ http_interactions:
       Referrer-Policy:
       - strict-origin-when-cross-origin
       X-Ep-Request-Uuid:
-      - 704d1f726218138ce78bafc500530edd
+      - '0991fb54625474cee786b41f002330a7'
       Cache-Control:
       - no-cache, no-store
       Pragma:
@@ -44,31 +44,29 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"91696d6f05e27c3c9279d19f9320bd2a"
-      X-Request-Id:
-      - bc7a888d-6f46-4d99-bace-119f36a2843a
+      - W/"0b3d4aae0f4caee935ffb4177d31faef"
       X-Runtime:
-      - '0.040141'
+      - '0.038811'
       Transfer-Encoding:
       - chunked
       X-Node:
-      - bigweb2nuq
+      - bigweb4nuq
       X-Version-Label:
-      - easypost-202202242013-00973e8608-master
+      - easypost-202204082123-da17cc1ac2-master
       X-Backend:
       - easypost
       X-Proxied:
-      - extlb2nuq 88c34981dc
-      - intlb2nuq 88c34981dc
+      - extlb2nuq fde591f008
+      - intlb2nuq fde591f008
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"shprep_c1c292290ee6438785d23c6cacd3b879","object":"ShipmentReport","created_at":"2022-02-24T23:23:56Z","updated_at":"2022-02-24T23:23:56Z","start_date":"2022-02-21","end_date":"2022-02-23","mode":"test","status":"new","url":null,"url_expires_at":null,"include_children":false}'
-  recorded_at: Thu, 24 Feb 2022 23:23:56 GMT
+      string: '{"id":"shprep_4b4e0861f4f244f4b9ffa21f7c329a2e","object":"ShipmentReport","created_at":"2022-04-11T18:34:54Z","updated_at":"2022-04-11T18:34:54Z","start_date":"2022-04-11","end_date":"2022-04-11","mode":"test","status":"new","url":null,"url_expires_at":null,"include_children":false}'
+  recorded_at: Mon, 11 Apr 2022 18:34:54 GMT
 - request:
     method: get
-    uri: https://api.easypost.com/v2/reports/shprep_c1c292290ee6438785d23c6cacd3b879
+    uri: https://api.easypost.com/v2/reports/shprep_4b4e0861f4f244f4b9ffa21f7c329a2e
     body:
       encoding: US-ASCII
       string: ''
@@ -78,7 +76,7 @@ http_interactions:
       Accept:
       - "*/*"
       User-Agent:
-      - EasyPost/v2 RubyClient/3.5.0 Ruby/3.1.0-p0
+      - EasyPost/v2 RubyClient/4.1.2 Ruby/3.1.1-p18
       Content-Type:
       - application/json
       Authorization: "<AUTHORIZATION>"
@@ -100,7 +98,7 @@ http_interactions:
       Referrer-Policy:
       - strict-origin-when-cross-origin
       X-Ep-Request-Uuid:
-      - 704d1f6d6218138de78bafc600530ee7
+      - '0991fb53625474cee786b420002330b4'
       Cache-Control:
       - no-cache, no-store
       Pragma:
@@ -110,26 +108,24 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"40b948689bb46cd84d35e2a71d2ec52a"
-      X-Request-Id:
-      - 6db6686f-eef1-4460-a1c8-47b83c702c50
+      - W/"0b3d4aae0f4caee935ffb4177d31faef"
       X-Runtime:
-      - '0.037276'
+      - '0.094894'
       Transfer-Encoding:
       - chunked
       X-Node:
-      - bigweb5nuq
+      - bigweb4nuq
       X-Version-Label:
-      - easypost-202202242013-00973e8608-master
+      - easypost-202204082123-da17cc1ac2-master
       X-Backend:
       - easypost
       X-Proxied:
-      - extlb2nuq 88c34981dc
-      - intlb2nuq 88c34981dc
+      - extlb2nuq fde591f008
+      - intlb1nuq fde591f008
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"shprep_c1c292290ee6438785d23c6cacd3b879","object":"ShipmentReport","created_at":"2022-02-24T23:23:56Z","updated_at":"2022-02-24T23:23:57Z","start_date":"2022-02-21","end_date":"2022-02-23","mode":"test","status":"empty","url":null,"url_expires_at":null,"include_children":false}'
-  recorded_at: Thu, 24 Feb 2022 23:23:57 GMT
+      string: '{"id":"shprep_4b4e0861f4f244f4b9ffa21f7c329a2e","object":"ShipmentReport","created_at":"2022-04-11T18:34:54Z","updated_at":"2022-04-11T18:34:54Z","start_date":"2022-04-11","end_date":"2022-04-11","mode":"test","status":"new","url":null,"url_expires_at":null,"include_children":false}'
+  recorded_at: Mon, 11 Apr 2022 18:34:54 GMT
 recorded_with: VCR 6.0.0

--- a/spec/report_spec.rb
+++ b/spec/report_spec.rb
@@ -6,8 +6,8 @@ describe EasyPost::Report do
   describe '.create' do
     it 'creates a report' do
       report = described_class.create(
-        start_date: Fixture.report_start_date,
-        end_date: Fixture.report_end_date,
+        start_date: Fixture.report_date,
+        end_date: Fixture.report_date,
         type: Fixture.report_type,
       )
 
@@ -17,8 +17,8 @@ describe EasyPost::Report do
 
     it 'creates a report with custom columns' do
       report = described_class.create(
-        start_date: Fixture.report_start_date,
-        end_date: Fixture.report_end_date,
+        start_date: Fixture.report_date,
+        end_date: Fixture.report_date,
         type: Fixture.report_type,
         columns: ['usps_zone'],
       )
@@ -30,8 +30,8 @@ describe EasyPost::Report do
 
     it 'creates a report with custom additional columns' do
       report = described_class.create(
-        start_date: Fixture.report_start_date,
-        end_date: Fixture.report_end_date,
+        start_date: Fixture.report_date,
+        end_date: Fixture.report_date,
         type: Fixture.report_type,
         additional_columns: %w[from_name from_company],
       )
@@ -45,9 +45,9 @@ describe EasyPost::Report do
   describe '.retrieve' do
     it 'retrieves a report' do
       report = described_class.create(
-        start_date: Fixture.report_start_date,
-        end_date: Fixture.report_end_date,
-        type: 'shipment',
+        start_date: Fixture.report_date,
+        end_date: Fixture.report_date,
+        type: Fixture.report_type,
       )
 
       retrieved_report = described_class.retrieve(report.id)
@@ -61,7 +61,7 @@ describe EasyPost::Report do
   describe '.all' do
     it 'retrieves all reports' do
       reports = described_class.all(
-        type: 'shipment',
+        type: Fixture.report_type,
         page_size: Fixture.page_size,
       )
 

--- a/spec/support/fixture.rb
+++ b/spec/support/fixture.rb
@@ -11,7 +11,8 @@ class Fixture
 
   # This is the USPS carrier account ID that comes with your EasyPost account by default and should be used for all tests
   def self.usps_carrier_account_id
-    ENV['USPS_CARRIER_ACCOUNT_ID'] || 'ca_716f33fd9fd348238b85c2922237f98b' # Fallback to the EasyPost Ruby Client Library Test User USPS carrier account
+    # Fallback to the EasyPost Ruby Client Library Test User USPS carrier account ID
+    ENV['USPS_CARRIER_ACCOUNT_ID'] || 'ca_716f33fd9fd348238b85c2922237f98b'
   end
 
   def self.usps
@@ -30,12 +31,13 @@ class Fixture
     'shipment'
   end
 
-  def self.report_start_date
-    (Date.today - 2).to_s
+  # If you need to re-record cassettes, increment this date by 1
+  def self.report_date
+    '2022-04-11'
   end
 
-  def self.report_end_date
-    Date.today.to_s
+  def self.webhook_url
+    'http://example.com'
   end
 
   def self.basic_address
@@ -155,11 +157,10 @@ class Fixture
   end
 
   # This fixture will require you to add a `shipment` key with a Shipment object from a test.
+  # If you need to re-record cassettes, increment the date below and ensure it is one day in the future,
   # USPS only does "next-day" pickups including Saturday but not Sunday or Holidays.
   def self.basic_pickup
-    weekday_num = Date.today.wday
-    weekday_offset = weekday_num == 5 ? 3 : 2 # Push our pickup date to the "next day" based on the day of the week
-    pickup_date = (Date.today + weekday_offset).to_s
+    pickup_date = '2022-04-12'
 
     {
       address: basic_address,

--- a/spec/webhook_spec.rb
+++ b/spec/webhook_spec.rb
@@ -6,12 +6,12 @@ describe EasyPost::Webhook do
   describe '.create' do
     it 'creates a webhook' do
       webhook = described_class.create(
-        url: 'http://example.com',
+        url: Fixture.webhook_url,
       )
 
       expect(webhook).to be_an_instance_of(described_class)
       expect(webhook.id).to match('hook_')
-      expect(webhook.url).to eq('http://example.com')
+      expect(webhook.url).to eq(Fixture.webhook_url)
 
       # Remove the webhook once we have tested it so we don't pollute the account with test webhooks
       webhook.delete
@@ -21,7 +21,7 @@ describe EasyPost::Webhook do
   describe '.retrieve' do
     it 'retrieves a webhook' do
       webhook = described_class.create(
-        url: 'http://example.com',
+        url: Fixture.webhook_url,
       )
 
       retrieved_webhook = described_class.retrieve(webhook.id)


### PR DESCRIPTION
Reverts to hard-coded dates to keep VCR happy into the future, simplifies the usage by consolidating the number of dates needed.