### PR TITLE
feat: adds lowest_rate to more objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## NEXT RELEASE
 
-- Add support for `columns` and `additional_columns` on Report creation
+- Adds a `lowest_rate` function to Orders and Pickups
+- Adds a `Shipment.get_lowest_smartrate` function and a `shipment.lowest_smartrate` function
 - Removes the unusable `carrier` param from `Address.create_and_verify` along with the dead `message` conditional check
 
 ## v4.1.2 (2022-03-16)

--- a/lib/easypost/order.rb
+++ b/lib/easypost/order.rb
@@ -29,4 +29,9 @@ class EasyPost::Order < EasyPost::Resource
   def self.all
     raise NotImplementedError.new('Order.all not implemented.')
   end
+
+  # Get the lowest rate of an Order (can exclude by having `'!'` as the first element of your optional filter lists).
+  def lowest_rate(carriers = [], services = [])
+    EasyPost::Util.get_lowest_object_rate(self, carriers, services)
+  end
 end

--- a/lib/easypost/pickup.rb
+++ b/lib/easypost/pickup.rb
@@ -29,4 +29,9 @@ class EasyPost::Pickup < EasyPost::Resource
   def self.all
     raise NotImplementedError.new('Pickup.all not implemented.')
   end
+
+  # Get the lowest rate of a Pickup (can exclude by having `'!'` as the first element of your optional filter lists).
+  def lowest_rate(carriers = [], services = [])
+    EasyPost::Util.get_lowest_object_rate(self, carriers, services, 'pickup_rates')
+  end
 end

--- a/lib/easypost/util.rb
+++ b/lib/easypost/util.rb
@@ -110,4 +110,56 @@ module EasyPost::Util
       response
     end
   end
+
+  # Gets the lowest rate of an EasyPost object such as a Shipment, Order, or Pickup.
+  # You can exclude by having `'!'` as the first element of your optional filter lists
+  def self.get_lowest_object_rate(easypost_object, carriers = [], services = [], rates_key = 'rates')
+    lowest_rate = nil
+
+    carriers = EasyPost::Util.normalize_string_list(carriers)
+    negative_carriers = []
+    carriers_copy = carriers.clone
+    carriers_copy.each do |carrier|
+      if carrier[0, 1] == '!'
+        negative_carriers << carrier[1..-1]
+        carriers.delete(carrier)
+      end
+    end
+
+    services = EasyPost::Util.normalize_string_list(services)
+    negative_services = []
+    services_copy = services.clone
+    services_copy.each do |service|
+      if service[0, 1] == '!'
+        negative_services << service[1..-1]
+        services.delete(service)
+      end
+    end
+
+    easypost_object[rates_key].each do |rate|
+      rate_carrier = rate.carrier.downcase
+      if carriers.size.positive? && !carriers.include?(rate_carrier)
+        next
+      end
+      if negative_carriers.size.positive? && negative_carriers.include?(rate_carrier)
+        next
+      end
+
+      rate_service = rate.service.downcase
+      if services.size.positive? && !services.include?(rate_service)
+        next
+      end
+      if negative_services.size.positive? && negative_services.include?(rate_service)
+        next
+      end
+
+      if lowest_rate.nil? || rate.rate.to_f < lowest_rate.rate.to_f
+        lowest_rate = rate
+      end
+    end
+
+    raise EasyPost::Error.new('No rates found.') if lowest_rate.nil?
+
+    lowest_rate
+  end
 end

--- a/spec/cassettes/order/EasyPost_Order_lowest_rate_tests_various_usage_alterations_of_the_lowest_rate_method.yml
+++ b/spec/cassettes/order/EasyPost_Order_lowest_rate_tests_various_usage_alterations_of_the_lowest_rate_method.yml
@@ -1,0 +1,92 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.easypost.com/v2/orders
+    body:
+      encoding: UTF-8
+      string: '{"order":{"from_address":{"name":"Jack Sparrow","company":"EasyPost","street1":"388
+        Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","phone":"5555555555"},"to_address":{"name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","phone":"5555555555"},"shipments":[{"to_address":{"name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","phone":"5555555555"},"from_address":{"name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","phone":"5555555555"},"parcel":{"length":"10","width":"8","height":"4","weight":"15.4"}}]}}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - EasyPost/v2 RubyClient/4.1.2 Ruby/3.1.1-p18
+      Content-Type:
+      - application/json
+      Authorization: "<AUTHORIZATION>"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      X-Ep-Request-Uuid:
+      - e9f28f7a626c3284e786bd200046ab5f
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Location:
+      - "/api/v2/orders/order_1f56d3db06cf4f94891e7b90f87f6843"
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"e782fc87d753687dcac6bf49381488a6"
+      X-Runtime:
+      - '0.211343'
+      Transfer-Encoding:
+      - chunked
+      X-Node:
+      - bigweb4nuq
+      X-Version-Label:
+      - easypost-202204282028-6188e715cb-master
+      X-Backend:
+      - easypost
+      X-Proxied:
+      - extlb1nuq 5fac7c1107
+      - intlb1nuq fde591f008
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: '{"mode":"test","reference":null,"is_return":false,"options":{"currency":"USD","payment":{"type":"SENDER"}},"messages":[],"created_at":"2022-04-29T18:46:28Z","updated_at":"2022-04-29T18:46:28Z","customs_info":null,"from_address":{"id":"adr_ae016118c7ec11ec8234ac1f6bc7bdc6","object":"Address","created_at":"2022-04-29T18:46:28+00:00","updated_at":"2022-04-29T18:46:28+00:00","name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"to_address":{"id":"adr_ae00281ac7ec11ec916bac1f6bc7b362","object":"Address","created_at":"2022-04-29T18:46:28+00:00","updated_at":"2022-04-29T18:46:28+00:00","name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_ae00281ac7ec11ec916bac1f6bc7b362","object":"Address","created_at":"2022-04-29T18:46:28+00:00","updated_at":"2022-04-29T18:46:28+00:00","name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"return_address":{"id":"adr_ae016118c7ec11ec8234ac1f6bc7bdc6","object":"Address","created_at":"2022-04-29T18:46:28+00:00","updated_at":"2022-04-29T18:46:28+00:00","name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"shipments":[{"created_at":"2022-04-29T18:46:28Z","is_return":false,"messages":[],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":null,"updated_at":"2022-04-29T18:46:28Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_ae016118c7ec11ec8234ac1f6bc7bdc6","object":"Address","created_at":"2022-04-29T18:46:28+00:00","updated_at":"2022-04-29T18:46:28+00:00","name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":"order_1f56d3db06cf4f94891e7b90f87f6843","parcel":{"id":"prcl_7473fb034b594cddb719daec204ccb49","object":"Parcel","created_at":"2022-04-29T18:46:28Z","updated_at":"2022-04-29T18:46:28Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":null,"rates":[{"id":"rate_70c93529e82046bb9adb41381a534164","object":"Rate","created_at":"2022-04-29T18:46:28Z","updated_at":"2022-04-29T18:46:28Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_4363d3392d5540cabbc9668da63cac55","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},{"id":"rate_659d67ae0c9947419835c037302e10e0","object":"Rate","created_at":"2022-04-29T18:46:28Z","updated_at":"2022-04-29T18:46:28Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_4363d3392d5540cabbc9668da63cac55","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},{"id":"rate_1e97063985b540b2a9f285107bdc973d","object":"Rate","created_at":"2022-04-29T18:46:28Z","updated_at":"2022-04-29T18:46:28Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_4363d3392d5540cabbc9668da63cac55","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},{"id":"rate_e00306cee6b24f7aa2c6060924784934","object":"Rate","created_at":"2022-04-29T18:46:28Z","updated_at":"2022-04-29T18:46:28Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_4363d3392d5540cabbc9668da63cac55","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"}],"refund_status":null,"scan_form":null,"selected_rate":null,"tracker":null,"to_address":{"id":"adr_ae00281ac7ec11ec916bac1f6bc7b362","object":"Address","created_at":"2022-04-29T18:46:28+00:00","updated_at":"2022-04-29T18:46:28+00:00","name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"usps_zone":1,"return_address":{"id":"adr_ae016118c7ec11ec8234ac1f6bc7bdc6","object":"Address","created_at":"2022-04-29T18:46:28+00:00","updated_at":"2022-04-29T18:46:28+00:00","name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_ae00281ac7ec11ec916bac1f6bc7b362","object":"Address","created_at":"2022-04-29T18:46:28+00:00","updated_at":"2022-04-29T18:46:28+00:00","name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"forms":[],"fees":[],"id":"shp_4363d3392d5540cabbc9668da63cac55","object":"Shipment"}],"rates":[{"id":"rate_70c93529e82046bb9adb41381a534164","object":"Rate","created_at":null,"updated_at":null,"mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_4363d3392d5540cabbc9668da63cac55","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},{"id":"rate_659d67ae0c9947419835c037302e10e0","object":"Rate","created_at":null,"updated_at":null,"mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_4363d3392d5540cabbc9668da63cac55","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},{"id":"rate_1e97063985b540b2a9f285107bdc973d","object":"Rate","created_at":null,"updated_at":null,"mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_4363d3392d5540cabbc9668da63cac55","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},{"id":"rate_e00306cee6b24f7aa2c6060924784934","object":"Rate","created_at":null,"updated_at":null,"mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_4363d3392d5540cabbc9668da63cac55","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"}],"id":"order_1f56d3db06cf4f94891e7b90f87f6843","object":"Order"}'
+  recorded_at: Fri, 29 Apr 2022 18:46:28 GMT
+recorded_with: VCR 6.0.0

--- a/spec/cassettes/pickup/EasyPost_Pickup_buy_buys_a_pickup.yml
+++ b/spec/cassettes/pickup/EasyPost_Pickup_buy_buys_a_pickup.yml
@@ -37,7 +37,7 @@ http_interactions:
       Referrer-Policy:
       - strict-origin-when-cross-origin
       X-Ep-Request-Uuid:
-      - '0991fb55625474c5e786b3fe00232d7c'
+      - e9f28f79626c325ce786bcdf00469a5b
       Cache-Control:
       - no-cache, no-store
       Pragma:
@@ -45,46 +45,46 @@ http_interactions:
       Expires:
       - '0'
       Location:
-      - "/api/v2/shipments/shp_89c8b7cacc8d424b9fcae6c5b91a5333"
+      - "/api/v2/shipments/shp_aa4a53120fb246f7977abbcb71af455f"
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"341cad3a6c4d220661aacf2e3f2af6de"
+      - W/"2ef919be85507b0305da7fe01050da1d"
       X-Runtime:
-      - '0.953641'
+      - '1.016930'
       Transfer-Encoding:
       - chunked
       X-Node:
-      - bigweb4nuq
+      - bigweb1nuq
       X-Version-Label:
-      - easypost-202204082123-da17cc1ac2-master
+      - easypost-202204282028-6188e715cb-master
       X-Backend:
       - easypost
       X-Proxied:
-      - extlb2nuq fde591f008
-      - intlb2nuq fde591f008
+      - extlb1nuq 5fac7c1107
+      - intlb1nuq fde591f008
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
     body:
       encoding: ASCII-8BIT
-      string: '{"created_at":"2022-04-11T18:34:45Z","is_return":false,"messages":[],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":"9400100109361114522113","updated_at":"2022-04-11T18:34:46Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_0f4a33bbb9c611ec9b71ac1f6bc72124","object":"Address","created_at":"2022-04-11T18:34:45+00:00","updated_at":"2022-04-11T18:34:45+00:00","name":"Jack
+      string: '{"created_at":"2022-04-29T18:45:48Z","is_return":false,"messages":[],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":"9400100109361117183366","updated_at":"2022-04-29T18:45:49Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_9645c770c7ec11ec8970ac1f6bc7b362","object":"Address","created_at":"2022-04-29T18:45:48+00:00","updated_at":"2022-04-29T18:45:48+00:00","name":"Jack
         Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_a175ade726814579878b3a1909587176","object":"Parcel","created_at":"2022-04-11T18:34:45Z","updated_at":"2022-04-11T18:34:45Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":{"object":"PostageLabel","id":"pl_f9752b2e2dfe4fb1a2543848196cc224","created_at":"2022-04-11T18:34:45Z","updated_at":"2022-04-11T18:34:46Z","date_advance":0,"integrated_form":"none","label_date":"2022-04-11T18:34:45Z","label_resolution":300,"label_size":"4x6","label_type":"default","label_file_type":"image/png","label_url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220411/b86f568e7eb94865aadb7df3c41d8d85.png","label_pdf_url":null,"label_zpl_url":null,"label_epl2_url":null,"label_file":null},"rates":[{"id":"rate_9667fbb152b3487a833dbe8956477bc4","object":"Rate","created_at":"2022-04-11T18:34:45Z","updated_at":"2022-04-11T18:34:45Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_89c8b7cacc8d424b9fcae6c5b91a5333","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},{"id":"rate_56ad7afefc61412e877dbd3a4885cea9","object":"Rate","created_at":"2022-04-11T18:34:45Z","updated_at":"2022-04-11T18:34:45Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_89c8b7cacc8d424b9fcae6c5b91a5333","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},{"id":"rate_939f758ca4e44c518cd7d46829d40d8f","object":"Rate","created_at":"2022-04-11T18:34:45Z","updated_at":"2022-04-11T18:34:45Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_89c8b7cacc8d424b9fcae6c5b91a5333","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},{"id":"rate_425ad05db5204499a394e1ae4b05f080","object":"Rate","created_at":"2022-04-11T18:34:45Z","updated_at":"2022-04-11T18:34:45Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_89c8b7cacc8d424b9fcae6c5b91a5333","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"}],"refund_status":null,"scan_form":null,"selected_rate":{"id":"rate_9667fbb152b3487a833dbe8956477bc4","object":"Rate","created_at":"2022-04-11T18:34:45Z","updated_at":"2022-04-11T18:34:45Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_89c8b7cacc8d424b9fcae6c5b91a5333","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},"tracker":{"id":"trk_fa5de6462188490db981584e0514bc1f","object":"Tracker","mode":"test","tracking_code":"9400100109361114522113","status":"unknown","status_detail":"unknown","created_at":"2022-04-11T18:34:46Z","updated_at":"2022-04-11T18:34:46Z","signed_by":null,"weight":null,"est_delivery_date":null,"shipment_id":"shp_89c8b7cacc8d424b9fcae6c5b91a5333","carrier":"USPS","tracking_details":[],"fees":[],"carrier_detail":null,"public_url":"https://track.easypost.com/djE6dHJrX2ZhNWRlNjQ2MjE4ODQ5MGRiOTgxNTg0ZTA1MTRiYzFm"},"to_address":{"id":"adr_0f4857d1b9c611ec9b6fac1f6bc72124","object":"Address","created_at":"2022-04-11T18:34:45+00:00","updated_at":"2022-04-11T18:34:45+00:00","name":"JACK
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_5bae958ebabe419e867573a269034887","object":"Parcel","created_at":"2022-04-29T18:45:48Z","updated_at":"2022-04-29T18:45:48Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":{"object":"PostageLabel","id":"pl_0eaeaba98885477abf960a2bcfa10128","created_at":"2022-04-29T18:45:49Z","updated_at":"2022-04-29T18:45:49Z","date_advance":0,"integrated_form":"none","label_date":"2022-04-29T18:45:49Z","label_resolution":300,"label_size":"4x6","label_type":"default","label_file_type":"image/png","label_url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220429/3d0528ba9e4d43938912b01ab9c2bc5b.png","label_pdf_url":null,"label_zpl_url":null,"label_epl2_url":null,"label_file":null},"rates":[{"id":"rate_c96b4489be1d4e9f921e6fadfd194b34","object":"Rate","created_at":"2022-04-29T18:45:49Z","updated_at":"2022-04-29T18:45:49Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_aa4a53120fb246f7977abbcb71af455f","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},{"id":"rate_73862e73e09a4acb9dc68002b338606f","object":"Rate","created_at":"2022-04-29T18:45:49Z","updated_at":"2022-04-29T18:45:49Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_aa4a53120fb246f7977abbcb71af455f","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},{"id":"rate_dcc299bd3a764bd39f34ca79e432d51c","object":"Rate","created_at":"2022-04-29T18:45:49Z","updated_at":"2022-04-29T18:45:49Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_aa4a53120fb246f7977abbcb71af455f","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},{"id":"rate_ed78f93ad5cf4cd88720f14df3ebc5b3","object":"Rate","created_at":"2022-04-29T18:45:49Z","updated_at":"2022-04-29T18:45:49Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_aa4a53120fb246f7977abbcb71af455f","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"}],"refund_status":null,"scan_form":null,"selected_rate":{"id":"rate_ed78f93ad5cf4cd88720f14df3ebc5b3","object":"Rate","created_at":"2022-04-29T18:45:49Z","updated_at":"2022-04-29T18:45:49Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_aa4a53120fb246f7977abbcb71af455f","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},"tracker":{"id":"trk_16fc5fcf081f492bb3357c9d67514bee","object":"Tracker","mode":"test","tracking_code":"9400100109361117183366","status":"unknown","status_detail":"unknown","created_at":"2022-04-29T18:45:49Z","updated_at":"2022-04-29T18:45:49Z","signed_by":null,"weight":null,"est_delivery_date":null,"shipment_id":"shp_aa4a53120fb246f7977abbcb71af455f","carrier":"USPS","tracking_details":[],"fees":[],"carrier_detail":null,"public_url":"https://track.easypost.com/djE6dHJrXzE2ZmM1ZmNmMDgxZjQ5MmJiMzM1N2M5ZDY3NTE0YmVl"},"to_address":{"id":"adr_9643764ec7ec11ecb00eac1f6bc72124","object":"Address","created_at":"2022-04-29T18:45:48+00:00","updated_at":"2022-04-29T18:45:49+00:00","name":"JACK
         SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN
-        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"usps_zone":1,"return_address":{"id":"adr_0f4a33bbb9c611ec9b71ac1f6bc72124","object":"Address","created_at":"2022-04-11T18:34:45+00:00","updated_at":"2022-04-11T18:34:45+00:00","name":"Jack
+        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"usps_zone":1,"return_address":{"id":"adr_9645c770c7ec11ec8970ac1f6bc7b362","object":"Address","created_at":"2022-04-29T18:45:48+00:00","updated_at":"2022-04-29T18:45:48+00:00","name":"Jack
         Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_0f4857d1b9c611ec9b6fac1f6bc72124","object":"Address","created_at":"2022-04-11T18:34:45+00:00","updated_at":"2022-04-11T18:34:45+00:00","name":"JACK
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_9643764ec7ec11ecb00eac1f6bc72124","object":"Address","created_at":"2022-04-29T18:45:48+00:00","updated_at":"2022-04-29T18:45:49+00:00","name":"JACK
         SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN
-        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"forms":[],"fees":[{"object":"Fee","type":"LabelFee","amount":"0.01000","charged":true,"refunded":false},{"object":"Fee","type":"PostageFee","amount":"5.49000","charged":true,"refunded":false}],"id":"shp_89c8b7cacc8d424b9fcae6c5b91a5333","object":"Shipment"}'
-  recorded_at: Mon, 11 Apr 2022 18:34:46 GMT
+        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"forms":[],"fees":[{"object":"Fee","type":"LabelFee","amount":"0.01000","charged":true,"refunded":false},{"object":"Fee","type":"PostageFee","amount":"5.49000","charged":true,"refunded":false}],"id":"shp_aa4a53120fb246f7977abbcb71af455f","object":"Shipment"}'
+  recorded_at: Fri, 29 Apr 2022 18:45:49 GMT
 - request:
     method: post
     uri: https://api.easypost.com/v2/pickups
     body:
       encoding: UTF-8
       string: '{"pickup":{"address":{"name":"Jack Sparrow","company":"EasyPost","street1":"388
-        Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","phone":"5555555555"},"min_datetime":"2022-04-12","max_datetime":"2022-04-12","instructions":"Pickup
-        at front door","shipment":{"id":"shp_89c8b7cacc8d424b9fcae6c5b91a5333"}}}'
+        Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","phone":"5555555555"},"min_datetime":"2022-05-01","max_datetime":"2022-05-01","instructions":"Pickup
+        at front door","shipment":{"id":"shp_aa4a53120fb246f7977abbcb71af455f"}}}'
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -113,7 +113,7 @@ http_interactions:
       Referrer-Policy:
       - strict-origin-when-cross-origin
       X-Ep-Request-Uuid:
-      - '0991fb56625474c6e786b3ff00232dd5'
+      - e9f28f7a626c325ee786bce100469ad7
       Cache-Control:
       - no-cache, no-store
       Pragma:
@@ -123,32 +123,32 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"2701402724fd8b7b412303beb3ea7b06"
+      - W/"035ce82d396e3d43db568a9d7f6b4fa0"
       X-Runtime:
-      - '0.766075'
+      - '1.327463'
       Transfer-Encoding:
       - chunked
       X-Node:
-      - bigweb6nuq
+      - bigweb9nuq
       X-Version-Label:
-      - easypost-202204082123-da17cc1ac2-master
+      - easypost-202204282028-6188e715cb-master
       X-Backend:
       - easypost
       X-Proxied:
-      - extlb2nuq fde591f008
+      - extlb1nuq 5fac7c1107
       - intlb2nuq fde591f008
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"pickup_4a157bd73ac249d683ad717e34ba2a33","object":"Pickup","created_at":"2022-04-11T18:34:46Z","updated_at":"2022-04-11T18:34:46Z","mode":"test","status":"unknown","reference":null,"min_datetime":"2022-04-12T00:00:00Z","max_datetime":"2022-04-12T00:00:00Z","is_account_address":false,"instructions":"Pickup
-        at front door","messages":[],"confirmation":null,"address":{"id":"adr_0ff7144cb9c611ec9ba3ac1f6bc72124","object":"Address","created_at":"2022-04-11T18:34:46+00:00","updated_at":"2022-04-11T18:34:46+00:00","name":"Jack
+      string: '{"id":"pickup_8b47c8ff747e439e9a35adb5c5b665a1","object":"Pickup","created_at":"2022-04-29T18:45:50Z","updated_at":"2022-04-29T18:45:50Z","mode":"test","status":"unknown","reference":null,"min_datetime":"2022-05-01T00:00:00Z","max_datetime":"2022-05-01T00:00:00Z","is_account_address":false,"instructions":"Pickup
+        at front door","messages":[],"confirmation":null,"address":{"id":"adr_96fc84e5c7ec11eca682ac1f6b0a0d1e","object":"Address","created_at":"2022-04-29T18:45:50+00:00","updated_at":"2022-04-29T18:45:50+00:00","name":"Jack
         Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"carrier_accounts":[],"pickup_rates":[{"mode":"test","service":"NextDay","rate":"0.00","currency":"USD","created_at":"2022-04-11T18:34:47Z","updated_at":"2022-04-11T18:34:47Z","carrier":"USPS","pickup_id":"pickup_4a157bd73ac249d683ad717e34ba2a33","id":"pickuprate_9f5b33aa06164f319b543ed0c8601b80","object":"PickupRate"}]}'
-  recorded_at: Mon, 11 Apr 2022 18:34:47 GMT
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"carrier_accounts":[],"pickup_rates":[{"mode":"test","service":"NextDay","rate":"0.00","currency":"USD","created_at":"2022-04-29T18:45:51Z","updated_at":"2022-04-29T18:45:51Z","carrier":"USPS","pickup_id":"pickup_8b47c8ff747e439e9a35adb5c5b665a1","id":"pickuprate_da748903a50d427b99e4f2b35fcbb46e","object":"PickupRate"}]}'
+  recorded_at: Fri, 29 Apr 2022 18:45:51 GMT
 - request:
     method: post
-    uri: https://api.easypost.com/v2/pickups/pickup_4a157bd73ac249d683ad717e34ba2a33/buy
+    uri: https://api.easypost.com/v2/pickups/pickup_8b47c8ff747e439e9a35adb5c5b665a1/buy
     body:
       encoding: UTF-8
       string: '{"carrier":"USPS","service":"NextDay"}'
@@ -180,7 +180,7 @@ http_interactions:
       Referrer-Policy:
       - strict-origin-when-cross-origin
       X-Ep-Request-Uuid:
-      - '0991fb57625474c7e786b40000232e37'
+      - e9f28f79626c325fe786bce400469b8c
       Cache-Control:
       - no-cache, no-store
       Pragma:
@@ -190,27 +190,29 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"39c0f282173e4cd54d4e92419ad6a0d1"
+      - W/"1df1d65a610f6a29d3aa0fa450ee22d6"
       X-Runtime:
-      - '1.077607'
+      - '1.490301'
       Transfer-Encoding:
       - chunked
       X-Node:
-      - bigweb5nuq
+      - bigweb7nuq
       X-Version-Label:
-      - easypost-202204082123-da17cc1ac2-master
+      - easypost-202204282028-6188e715cb-master
       X-Backend:
       - easypost
+      X-Canary:
+      - direct
       X-Proxied:
-      - extlb2nuq fde591f008
-      - intlb2nuq fde591f008
+      - extlb1nuq 5fac7c1107
+      - intlb1nuq fde591f008
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"pickup_4a157bd73ac249d683ad717e34ba2a33","object":"Pickup","created_at":"2022-04-11T18:34:46Z","updated_at":"2022-04-11T18:34:48Z","mode":"test","status":"scheduled","reference":null,"min_datetime":"2022-04-12T00:00:00Z","max_datetime":"2022-04-12T00:00:00Z","is_account_address":false,"instructions":"Pickup
-        at front door","messages":[],"confirmation":"WTC61774816","address":{"id":"adr_0ff7144cb9c611ec9ba3ac1f6bc72124","object":"Address","created_at":"2022-04-11T18:34:46+00:00","updated_at":"2022-04-11T18:34:46+00:00","name":"Jack
+      string: '{"id":"pickup_8b47c8ff747e439e9a35adb5c5b665a1","object":"Pickup","created_at":"2022-04-29T18:45:50Z","updated_at":"2022-04-29T18:45:53Z","mode":"test","status":"scheduled","reference":null,"min_datetime":"2022-05-01T00:00:00Z","max_datetime":"2022-05-01T00:00:00Z","is_account_address":false,"instructions":"Pickup
+        at front door","messages":[],"confirmation":"WTC61776846","address":{"id":"adr_96fc84e5c7ec11eca682ac1f6b0a0d1e","object":"Address","created_at":"2022-04-29T18:45:50+00:00","updated_at":"2022-04-29T18:45:50+00:00","name":"Jack
         Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"carrier_accounts":[],"pickup_rates":[{"mode":"test","service":"NextDay","rate":"0.00","currency":"USD","created_at":"2022-04-11T18:34:47Z","updated_at":"2022-04-11T18:34:47Z","carrier":"USPS","pickup_id":"pickup_4a157bd73ac249d683ad717e34ba2a33","id":"pickuprate_9f5b33aa06164f319b543ed0c8601b80","object":"PickupRate"}]}'
-  recorded_at: Mon, 11 Apr 2022 18:34:48 GMT
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"carrier_accounts":[],"pickup_rates":[{"mode":"test","service":"NextDay","rate":"0.00","currency":"USD","created_at":"2022-04-29T18:45:51Z","updated_at":"2022-04-29T18:45:51Z","carrier":"USPS","pickup_id":"pickup_8b47c8ff747e439e9a35adb5c5b665a1","id":"pickuprate_da748903a50d427b99e4f2b35fcbb46e","object":"PickupRate"}]}'
+  recorded_at: Fri, 29 Apr 2022 18:45:53 GMT
 recorded_with: VCR 6.0.0

--- a/spec/cassettes/pickup/EasyPost_Pickup_cancel_cancels_a_pickup.yml
+++ b/spec/cassettes/pickup/EasyPost_Pickup_cancel_cancels_a_pickup.yml
@@ -37,7 +37,7 @@ http_interactions:
       Referrer-Policy:
       - strict-origin-when-cross-origin
       X-Ep-Request-Uuid:
-      - '0991fb52625474c8e786b40100232eb9'
+      - e9f28f76626c3261e786bce500469c3e
       Cache-Control:
       - no-cache, no-store
       Pragma:
@@ -45,46 +45,46 @@ http_interactions:
       Expires:
       - '0'
       Location:
-      - "/api/v2/shipments/shp_238da2da32894d2396d8619b8e64f06d"
+      - "/api/v2/shipments/shp_2f9488a42b43445f9abcb48d0357e20e"
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"5da1d6ed7c70f8e690299de1d52174f9"
+      - W/"55aece30f7c540a174fef211a6ca4097"
       X-Runtime:
-      - '0.930758'
+      - '0.865790'
       Transfer-Encoding:
       - chunked
       X-Node:
-      - bigweb9nuq
+      - bigweb4nuq
       X-Version-Label:
-      - easypost-202204082123-da17cc1ac2-master
+      - easypost-202204282028-6188e715cb-master
       X-Backend:
       - easypost
       X-Proxied:
-      - extlb2nuq fde591f008
-      - intlb2nuq fde591f008
+      - extlb1nuq 5fac7c1107
+      - intlb1nuq fde591f008
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
     body:
       encoding: ASCII-8BIT
-      string: '{"created_at":"2022-04-11T18:34:48Z","is_return":false,"messages":[],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":"9400100109361114522120","updated_at":"2022-04-11T18:34:49Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_116b748cb9c611ec83d9ac1f6bc7b362","object":"Address","created_at":"2022-04-11T18:34:48+00:00","updated_at":"2022-04-11T18:34:48+00:00","name":"Jack
+      string: '{"created_at":"2022-04-29T18:45:53Z","is_return":false,"messages":[],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":"9400100109361117183373","updated_at":"2022-04-29T18:45:54Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_98e817dfc7ec11eca754ac1f6b0a0d1e","object":"Address","created_at":"2022-04-29T18:45:53+00:00","updated_at":"2022-04-29T18:45:53+00:00","name":"Jack
         Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_035748421a2846a4bd2ff181a0998928","object":"Parcel","created_at":"2022-04-11T18:34:48Z","updated_at":"2022-04-11T18:34:48Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":{"object":"PostageLabel","id":"pl_9d604a62b7974712a8f9ac31901b7a33","created_at":"2022-04-11T18:34:49Z","updated_at":"2022-04-11T18:34:49Z","date_advance":0,"integrated_form":"none","label_date":"2022-04-11T18:34:49Z","label_resolution":300,"label_size":"4x6","label_type":"default","label_file_type":"image/png","label_url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220411/03ca0d800e484defb56196a8b91b2a16.png","label_pdf_url":null,"label_zpl_url":null,"label_epl2_url":null,"label_file":null},"rates":[{"id":"rate_8a81ca44fcd943e188c6fe7fa5542010","object":"Rate","created_at":"2022-04-11T18:34:48Z","updated_at":"2022-04-11T18:34:48Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_238da2da32894d2396d8619b8e64f06d","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},{"id":"rate_6a897c1f622f46a9b5f6055307ecf3a4","object":"Rate","created_at":"2022-04-11T18:34:48Z","updated_at":"2022-04-11T18:34:48Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_238da2da32894d2396d8619b8e64f06d","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},{"id":"rate_e82dd84336d4402f8a567c9da1d8c536","object":"Rate","created_at":"2022-04-11T18:34:48Z","updated_at":"2022-04-11T18:34:48Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_238da2da32894d2396d8619b8e64f06d","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},{"id":"rate_b935cdf5c36f48c2bbb6eca780be9a80","object":"Rate","created_at":"2022-04-11T18:34:48Z","updated_at":"2022-04-11T18:34:48Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_238da2da32894d2396d8619b8e64f06d","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"}],"refund_status":null,"scan_form":null,"selected_rate":{"id":"rate_b935cdf5c36f48c2bbb6eca780be9a80","object":"Rate","created_at":"2022-04-11T18:34:49Z","updated_at":"2022-04-11T18:34:49Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_238da2da32894d2396d8619b8e64f06d","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},"tracker":{"id":"trk_b442d09741d84f93b371b09662b4b36b","object":"Tracker","mode":"test","tracking_code":"9400100109361114522120","status":"unknown","status_detail":"unknown","created_at":"2022-04-11T18:34:49Z","updated_at":"2022-04-11T18:34:49Z","signed_by":null,"weight":null,"est_delivery_date":null,"shipment_id":"shp_238da2da32894d2396d8619b8e64f06d","carrier":"USPS","tracking_details":[],"fees":[],"carrier_detail":null,"public_url":"https://track.easypost.com/djE6dHJrX2I0NDJkMDk3NDFkODRmOTNiMzcxYjA5NjYyYjRiMzZi"},"to_address":{"id":"adr_1169b2d5b9c611ec84e0ac1f6b0a0d1e","object":"Address","created_at":"2022-04-11T18:34:48+00:00","updated_at":"2022-04-11T18:34:49+00:00","name":"JACK
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_f2e496275bb4465f8c18afac1634c0b3","object":"Parcel","created_at":"2022-04-29T18:45:53Z","updated_at":"2022-04-29T18:45:53Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":{"object":"PostageLabel","id":"pl_5fcdd531e6884ab580a40b68873ca10e","created_at":"2022-04-29T18:45:53Z","updated_at":"2022-04-29T18:45:53Z","date_advance":0,"integrated_form":"none","label_date":"2022-04-29T18:45:53Z","label_resolution":300,"label_size":"4x6","label_type":"default","label_file_type":"image/png","label_url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220429/7e3d39363a314a3ba8094fc9d02aeffb.png","label_pdf_url":null,"label_zpl_url":null,"label_epl2_url":null,"label_file":null},"rates":[{"id":"rate_96f2cbd306fc40de9785ef530e97c2eb","object":"Rate","created_at":"2022-04-29T18:45:53Z","updated_at":"2022-04-29T18:45:53Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_2f9488a42b43445f9abcb48d0357e20e","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},{"id":"rate_d82bcaafa5d44c43946ba1539adab71c","object":"Rate","created_at":"2022-04-29T18:45:53Z","updated_at":"2022-04-29T18:45:53Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_2f9488a42b43445f9abcb48d0357e20e","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},{"id":"rate_b3fdf06fe7544b87b47954cac6666093","object":"Rate","created_at":"2022-04-29T18:45:53Z","updated_at":"2022-04-29T18:45:53Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_2f9488a42b43445f9abcb48d0357e20e","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},{"id":"rate_ce74d28fb26a4b6bbbd2c8f9a4434a6f","object":"Rate","created_at":"2022-04-29T18:45:53Z","updated_at":"2022-04-29T18:45:53Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_2f9488a42b43445f9abcb48d0357e20e","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"}],"refund_status":null,"scan_form":null,"selected_rate":{"id":"rate_ce74d28fb26a4b6bbbd2c8f9a4434a6f","object":"Rate","created_at":"2022-04-29T18:45:53Z","updated_at":"2022-04-29T18:45:53Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_2f9488a42b43445f9abcb48d0357e20e","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},"tracker":{"id":"trk_b47227ad9dc047278d97524b2b3f164b","object":"Tracker","mode":"test","tracking_code":"9400100109361117183373","status":"unknown","status_detail":"unknown","created_at":"2022-04-29T18:45:54Z","updated_at":"2022-04-29T18:45:54Z","signed_by":null,"weight":null,"est_delivery_date":null,"shipment_id":"shp_2f9488a42b43445f9abcb48d0357e20e","carrier":"USPS","tracking_details":[],"fees":[],"carrier_detail":null,"public_url":"https://track.easypost.com/djE6dHJrX2I0NzIyN2FkOWRjMDQ3Mjc4ZDk3NTI0YjJiM2YxNjRi"},"to_address":{"id":"adr_98e564fcc7ec11eca752ac1f6b0a0d1e","object":"Address","created_at":"2022-04-29T18:45:53+00:00","updated_at":"2022-04-29T18:45:53+00:00","name":"JACK
         SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN
-        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"usps_zone":1,"return_address":{"id":"adr_116b748cb9c611ec83d9ac1f6bc7b362","object":"Address","created_at":"2022-04-11T18:34:48+00:00","updated_at":"2022-04-11T18:34:48+00:00","name":"Jack
+        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"usps_zone":1,"return_address":{"id":"adr_98e817dfc7ec11eca754ac1f6b0a0d1e","object":"Address","created_at":"2022-04-29T18:45:53+00:00","updated_at":"2022-04-29T18:45:53+00:00","name":"Jack
         Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_1169b2d5b9c611ec84e0ac1f6b0a0d1e","object":"Address","created_at":"2022-04-11T18:34:48+00:00","updated_at":"2022-04-11T18:34:49+00:00","name":"JACK
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_98e564fcc7ec11eca752ac1f6b0a0d1e","object":"Address","created_at":"2022-04-29T18:45:53+00:00","updated_at":"2022-04-29T18:45:53+00:00","name":"JACK
         SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN
-        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"forms":[],"fees":[{"object":"Fee","type":"LabelFee","amount":"0.01000","charged":true,"refunded":false},{"object":"Fee","type":"PostageFee","amount":"5.49000","charged":true,"refunded":false}],"id":"shp_238da2da32894d2396d8619b8e64f06d","object":"Shipment"}'
-  recorded_at: Mon, 11 Apr 2022 18:34:49 GMT
+        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"forms":[],"fees":[{"object":"Fee","type":"LabelFee","amount":"0.01000","charged":true,"refunded":false},{"object":"Fee","type":"PostageFee","amount":"5.49000","charged":true,"refunded":false}],"id":"shp_2f9488a42b43445f9abcb48d0357e20e","object":"Shipment"}'
+  recorded_at: Fri, 29 Apr 2022 18:45:54 GMT
 - request:
     method: post
     uri: https://api.easypost.com/v2/pickups
     body:
       encoding: UTF-8
       string: '{"pickup":{"address":{"name":"Jack Sparrow","company":"EasyPost","street1":"388
-        Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","phone":"5555555555"},"min_datetime":"2022-04-12","max_datetime":"2022-04-12","instructions":"Pickup
-        at front door","shipment":{"id":"shp_238da2da32894d2396d8619b8e64f06d"}}}'
+        Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","phone":"5555555555"},"min_datetime":"2022-05-01","max_datetime":"2022-05-01","instructions":"Pickup
+        at front door","shipment":{"id":"shp_2f9488a42b43445f9abcb48d0357e20e"}}}'
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -113,7 +113,7 @@ http_interactions:
       Referrer-Policy:
       - strict-origin-when-cross-origin
       X-Ep-Request-Uuid:
-      - '0991fb55625474c9e786b40200232f22'
+      - e9f28f79626c3262e786bce600469cba
       Cache-Control:
       - no-cache, no-store
       Pragma:
@@ -123,32 +123,32 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"b4c45b750bfd5539b9507a1fa7a937be"
+      - W/"c0053cdd65ccf9966a3e95f32a030822"
       X-Runtime:
-      - '0.801241'
+      - '1.025769'
       Transfer-Encoding:
       - chunked
       X-Node:
       - bigweb4nuq
       X-Version-Label:
-      - easypost-202204082123-da17cc1ac2-master
+      - easypost-202204282028-6188e715cb-master
       X-Backend:
       - easypost
       X-Proxied:
-      - extlb2nuq fde591f008
+      - extlb1nuq 5fac7c1107
       - intlb1nuq fde591f008
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"pickup_d243ac138d9a4fb3af003169b70034be","object":"Pickup","created_at":"2022-04-11T18:34:50Z","updated_at":"2022-04-11T18:34:50Z","mode":"test","status":"unknown","reference":null,"min_datetime":"2022-04-12T00:00:00Z","max_datetime":"2022-04-12T00:00:00Z","is_account_address":false,"instructions":"Pickup
-        at front door","messages":[],"confirmation":null,"address":{"id":"adr_1215dea7b9c611ec9c6cac1f6bc72124","object":"Address","created_at":"2022-04-11T18:34:49+00:00","updated_at":"2022-04-11T18:34:49+00:00","name":"Jack
+      string: '{"id":"pickup_f034ff29a7724147956e38725d73ea6d","object":"Pickup","created_at":"2022-04-29T18:45:54Z","updated_at":"2022-04-29T18:45:54Z","mode":"test","status":"unknown","reference":null,"min_datetime":"2022-05-01T00:00:00Z","max_datetime":"2022-05-01T00:00:00Z","is_account_address":false,"instructions":"Pickup
+        at front door","messages":[],"confirmation":null,"address":{"id":"adr_998831fac7ec11ec8ab9ac1f6bc7b362","object":"Address","created_at":"2022-04-29T18:45:54+00:00","updated_at":"2022-04-29T18:45:54+00:00","name":"Jack
         Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"carrier_accounts":[],"pickup_rates":[{"mode":"test","service":"NextDay","rate":"0.00","currency":"USD","created_at":"2022-04-11T18:34:50Z","updated_at":"2022-04-11T18:34:50Z","carrier":"USPS","pickup_id":"pickup_d243ac138d9a4fb3af003169b70034be","id":"pickuprate_5f8f61fc5598439d855d7f8a121aa65f","object":"PickupRate"}]}'
-  recorded_at: Mon, 11 Apr 2022 18:34:50 GMT
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"carrier_accounts":[],"pickup_rates":[{"mode":"test","service":"NextDay","rate":"0.00","currency":"USD","created_at":"2022-04-29T18:45:55Z","updated_at":"2022-04-29T18:45:55Z","carrier":"USPS","pickup_id":"pickup_f034ff29a7724147956e38725d73ea6d","id":"pickuprate_55e38babb58744c5aeff1795162ba49e","object":"PickupRate"}]}'
+  recorded_at: Fri, 29 Apr 2022 18:45:55 GMT
 - request:
     method: post
-    uri: https://api.easypost.com/v2/pickups/pickup_d243ac138d9a4fb3af003169b70034be/buy
+    uri: https://api.easypost.com/v2/pickups/pickup_f034ff29a7724147956e38725d73ea6d/buy
     body:
       encoding: UTF-8
       string: '{"carrier":"USPS","service":"NextDay"}'
@@ -180,7 +180,7 @@ http_interactions:
       Referrer-Policy:
       - strict-origin-when-cross-origin
       X-Ep-Request-Uuid:
-      - '0991fb55625474cae786b41a00232f85'
+      - e9f28f73626c3263e786bcff00469d48
       Cache-Control:
       - no-cache, no-store
       Pragma:
@@ -190,32 +190,32 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"70a5c6df522e69135162170e1227b756"
+      - W/"37c8b825c0ff959e7c04c76d150b6b8f"
       X-Runtime:
-      - '1.040029'
+      - '1.349091'
       Transfer-Encoding:
       - chunked
       X-Node:
-      - bigweb3nuq
+      - bigweb4nuq
       X-Version-Label:
-      - easypost-202204082123-da17cc1ac2-master
+      - easypost-202204282028-6188e715cb-master
       X-Backend:
       - easypost
       X-Proxied:
-      - extlb2nuq fde591f008
-      - intlb2nuq fde591f008
+      - extlb1nuq 5fac7c1107
+      - intlb1nuq fde591f008
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"pickup_d243ac138d9a4fb3af003169b70034be","object":"Pickup","created_at":"2022-04-11T18:34:50Z","updated_at":"2022-04-11T18:34:51Z","mode":"test","status":"scheduled","reference":null,"min_datetime":"2022-04-12T00:00:00Z","max_datetime":"2022-04-12T00:00:00Z","is_account_address":false,"instructions":"Pickup
-        at front door","messages":[],"confirmation":"WTC61774818","address":{"id":"adr_1215dea7b9c611ec9c6cac1f6bc72124","object":"Address","created_at":"2022-04-11T18:34:49+00:00","updated_at":"2022-04-11T18:34:49+00:00","name":"Jack
+      string: '{"id":"pickup_f034ff29a7724147956e38725d73ea6d","object":"Pickup","created_at":"2022-04-29T18:45:54Z","updated_at":"2022-04-29T18:45:56Z","mode":"test","status":"scheduled","reference":null,"min_datetime":"2022-05-01T00:00:00Z","max_datetime":"2022-05-01T00:00:00Z","is_account_address":false,"instructions":"Pickup
+        at front door","messages":[],"confirmation":"WTC61776848","address":{"id":"adr_998831fac7ec11ec8ab9ac1f6bc7b362","object":"Address","created_at":"2022-04-29T18:45:54+00:00","updated_at":"2022-04-29T18:45:54+00:00","name":"Jack
         Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"carrier_accounts":[],"pickup_rates":[{"mode":"test","service":"NextDay","rate":"0.00","currency":"USD","created_at":"2022-04-11T18:34:50Z","updated_at":"2022-04-11T18:34:50Z","carrier":"USPS","pickup_id":"pickup_d243ac138d9a4fb3af003169b70034be","id":"pickuprate_5f8f61fc5598439d855d7f8a121aa65f","object":"PickupRate"}]}'
-  recorded_at: Mon, 11 Apr 2022 18:34:51 GMT
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"carrier_accounts":[],"pickup_rates":[{"mode":"test","service":"NextDay","rate":"0.00","currency":"USD","created_at":"2022-04-29T18:45:55Z","updated_at":"2022-04-29T18:45:55Z","carrier":"USPS","pickup_id":"pickup_f034ff29a7724147956e38725d73ea6d","id":"pickuprate_55e38babb58744c5aeff1795162ba49e","object":"PickupRate"}]}'
+  recorded_at: Fri, 29 Apr 2022 18:45:56 GMT
 - request:
     method: post
-    uri: https://api.easypost.com/v2/pickups/pickup_d243ac138d9a4fb3af003169b70034be/cancel
+    uri: https://api.easypost.com/v2/pickups/pickup_f034ff29a7724147956e38725d73ea6d/cancel
     body:
       encoding: UTF-8
       string: "{}"
@@ -247,7 +247,7 @@ http_interactions:
       Referrer-Policy:
       - strict-origin-when-cross-origin
       X-Ep-Request-Uuid:
-      - '0991fb54625474cce786b41b00232fed'
+      - e9f28f75626c3265e786bd0000469de9
       Cache-Control:
       - no-cache, no-store
       Pragma:
@@ -257,27 +257,27 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"e859380b4f3d917d0d8aa5ca42605919"
+      - W/"c8f556bbee062ac6f4e1f41a88aa0f58"
       X-Runtime:
-      - '0.966242'
+      - '0.934904'
       Transfer-Encoding:
       - chunked
       X-Node:
-      - bigweb9nuq
+      - bigweb1nuq
       X-Version-Label:
-      - easypost-202204082123-da17cc1ac2-master
+      - easypost-202204282028-6188e715cb-master
       X-Backend:
       - easypost
       X-Proxied:
-      - extlb2nuq fde591f008
-      - intlb1nuq fde591f008
+      - extlb1nuq 5fac7c1107
+      - intlb2nuq fde591f008
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"pickup_d243ac138d9a4fb3af003169b70034be","object":"Pickup","created_at":"2022-04-11T18:34:50Z","updated_at":"2022-04-11T18:34:53Z","mode":"test","status":"canceled","reference":null,"min_datetime":"2022-04-12T00:00:00Z","max_datetime":"2022-04-12T00:00:00Z","is_account_address":false,"instructions":"Pickup
-        at front door","messages":[],"confirmation":"WTC61774818","address":{"id":"adr_1215dea7b9c611ec9c6cac1f6bc72124","object":"Address","created_at":"2022-04-11T18:34:49+00:00","updated_at":"2022-04-11T18:34:49+00:00","name":"Jack
+      string: '{"id":"pickup_f034ff29a7724147956e38725d73ea6d","object":"Pickup","created_at":"2022-04-29T18:45:54Z","updated_at":"2022-04-29T18:45:58Z","mode":"test","status":"canceled","reference":null,"min_datetime":"2022-05-01T00:00:00Z","max_datetime":"2022-05-01T00:00:00Z","is_account_address":false,"instructions":"Pickup
+        at front door","messages":[],"confirmation":"WTC61776848","address":{"id":"adr_998831fac7ec11ec8ab9ac1f6bc7b362","object":"Address","created_at":"2022-04-29T18:45:54+00:00","updated_at":"2022-04-29T18:45:54+00:00","name":"Jack
         Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"carrier_accounts":[],"pickup_rates":[{"mode":"test","service":"NextDay","rate":"0.00","currency":"USD","created_at":"2022-04-11T18:34:50Z","updated_at":"2022-04-11T18:34:50Z","carrier":"USPS","pickup_id":"pickup_d243ac138d9a4fb3af003169b70034be","id":"pickuprate_5f8f61fc5598439d855d7f8a121aa65f","object":"PickupRate"}]}'
-  recorded_at: Mon, 11 Apr 2022 18:34:53 GMT
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"carrier_accounts":[],"pickup_rates":[{"mode":"test","service":"NextDay","rate":"0.00","currency":"USD","created_at":"2022-04-29T18:45:55Z","updated_at":"2022-04-29T18:45:55Z","carrier":"USPS","pickup_id":"pickup_f034ff29a7724147956e38725d73ea6d","id":"pickuprate_55e38babb58744c5aeff1795162ba49e","object":"PickupRate"}]}'
+  recorded_at: Fri, 29 Apr 2022 18:45:57 GMT
 recorded_with: VCR 6.0.0

--- a/spec/cassettes/pickup/EasyPost_Pickup_create_creates_a_pickup.yml
+++ b/spec/cassettes/pickup/EasyPost_Pickup_create_creates_a_pickup.yml
@@ -37,7 +37,7 @@ http_interactions:
       Referrer-Policy:
       - strict-origin-when-cross-origin
       X-Ep-Request-Uuid:
-      - '0991fb57625474c0e786b3f900232b59'
+      - e9f28f7a626c3257e786bcc300469836
       Cache-Control:
       - no-cache, no-store
       Pragma:
@@ -45,46 +45,46 @@ http_interactions:
       Expires:
       - '0'
       Location:
-      - "/api/v2/shipments/shp_e2b8ec8d75c34627b07312b9ee9960d5"
+      - "/api/v2/shipments/shp_54788167f5ff4560b7a96a04e912a59c"
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"05ac7b1b1d42187f551099c135e5eb3a"
+      - W/"b728d1deecd182ed317d7b4635fa1199"
       X-Runtime:
-      - '0.991916'
+      - '0.835451'
       Transfer-Encoding:
       - chunked
       X-Node:
       - bigweb6nuq
       X-Version-Label:
-      - easypost-202204082123-da17cc1ac2-master
+      - easypost-202204282028-6188e715cb-master
       X-Backend:
       - easypost
       X-Proxied:
-      - extlb2nuq fde591f008
+      - extlb1nuq 5fac7c1107
       - intlb1nuq fde591f008
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
     body:
       encoding: ASCII-8BIT
-      string: '{"created_at":"2022-04-11T18:34:40Z","is_return":false,"messages":[],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":"9400100109361114522090","updated_at":"2022-04-11T18:34:41Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_0c4dde30b9c611ec8319ac1f6b0a0d1e","object":"Address","created_at":"2022-04-11T18:34:40+00:00","updated_at":"2022-04-11T18:34:40+00:00","name":"Jack
+      string: '{"created_at":"2022-04-29T18:45:43Z","is_return":false,"messages":[],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":"9400100109361117183342","updated_at":"2022-04-29T18:45:44Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_932941dac7ec11eca530ac1f6b0a0d1e","object":"Address","created_at":"2022-04-29T18:45:43+00:00","updated_at":"2022-04-29T18:45:43+00:00","name":"Jack
         Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_b9d0a3eba89b490c81ee79a9dde47485","object":"Parcel","created_at":"2022-04-11T18:34:40Z","updated_at":"2022-04-11T18:34:40Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":{"object":"PostageLabel","id":"pl_26fa45fa12fa4eff903043b8192d0769","created_at":"2022-04-11T18:34:40Z","updated_at":"2022-04-11T18:34:41Z","date_advance":0,"integrated_form":"none","label_date":"2022-04-11T18:34:40Z","label_resolution":300,"label_size":"4x6","label_type":"default","label_file_type":"image/png","label_url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220411/641f0c67933e413fac9e057dbae05eac.png","label_pdf_url":null,"label_zpl_url":null,"label_epl2_url":null,"label_file":null},"rates":[{"id":"rate_511904cb02c94dcfa595ac64e318f8d4","object":"Rate","created_at":"2022-04-11T18:34:40Z","updated_at":"2022-04-11T18:34:40Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_e2b8ec8d75c34627b07312b9ee9960d5","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},{"id":"rate_928668d4b9d14bf683b18eef467c4a06","object":"Rate","created_at":"2022-04-11T18:34:40Z","updated_at":"2022-04-11T18:34:40Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_e2b8ec8d75c34627b07312b9ee9960d5","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},{"id":"rate_de14e74565434c44867401d38ade2633","object":"Rate","created_at":"2022-04-11T18:34:40Z","updated_at":"2022-04-11T18:34:40Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_e2b8ec8d75c34627b07312b9ee9960d5","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},{"id":"rate_1f0162e14d2d48d0a9eaf26d1c3fb691","object":"Rate","created_at":"2022-04-11T18:34:40Z","updated_at":"2022-04-11T18:34:40Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_e2b8ec8d75c34627b07312b9ee9960d5","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"}],"refund_status":null,"scan_form":null,"selected_rate":{"id":"rate_511904cb02c94dcfa595ac64e318f8d4","object":"Rate","created_at":"2022-04-11T18:34:40Z","updated_at":"2022-04-11T18:34:40Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_e2b8ec8d75c34627b07312b9ee9960d5","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},"tracker":{"id":"trk_43e805b6bb2b4086a561c42458c0f456","object":"Tracker","mode":"test","tracking_code":"9400100109361114522090","status":"unknown","status_detail":"unknown","created_at":"2022-04-11T18:34:41Z","updated_at":"2022-04-11T18:34:41Z","signed_by":null,"weight":null,"est_delivery_date":null,"shipment_id":"shp_e2b8ec8d75c34627b07312b9ee9960d5","carrier":"USPS","tracking_details":[],"fees":[],"carrier_detail":null,"public_url":"https://track.easypost.com/djE6dHJrXzQzZTgwNWI2YmIyYjQwODZhNTYxYzQyNDU4YzBmNDU2"},"to_address":{"id":"adr_0c4b65a9b9c611ec9a53ac1f6bc72124","object":"Address","created_at":"2022-04-11T18:34:40+00:00","updated_at":"2022-04-11T18:34:40+00:00","name":"JACK
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_b517c11a438b40aab6342e65f1c0bb2d","object":"Parcel","created_at":"2022-04-29T18:45:43Z","updated_at":"2022-04-29T18:45:43Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":{"object":"PostageLabel","id":"pl_f51a90ef79b94f899b97802162df8a83","created_at":"2022-04-29T18:45:44Z","updated_at":"2022-04-29T18:45:44Z","date_advance":0,"integrated_form":"none","label_date":"2022-04-29T18:45:44Z","label_resolution":300,"label_size":"4x6","label_type":"default","label_file_type":"image/png","label_url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220429/62c4dd4ff7ba40f3a11e8efabf23f6c7.png","label_pdf_url":null,"label_zpl_url":null,"label_epl2_url":null,"label_file":null},"rates":[{"id":"rate_b8fdfd4ce31b4fb5976bc10ac8d7e5e7","object":"Rate","created_at":"2022-04-29T18:45:43Z","updated_at":"2022-04-29T18:45:43Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_54788167f5ff4560b7a96a04e912a59c","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},{"id":"rate_fa173b95ec4f4aedbebd3611a1bc877f","object":"Rate","created_at":"2022-04-29T18:45:43Z","updated_at":"2022-04-29T18:45:43Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_54788167f5ff4560b7a96a04e912a59c","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},{"id":"rate_fdef856a598f4145b4bc6cb8cb4e4c9b","object":"Rate","created_at":"2022-04-29T18:45:43Z","updated_at":"2022-04-29T18:45:43Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_54788167f5ff4560b7a96a04e912a59c","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},{"id":"rate_a09383c500bc46588ed029fd44719843","object":"Rate","created_at":"2022-04-29T18:45:43Z","updated_at":"2022-04-29T18:45:43Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_54788167f5ff4560b7a96a04e912a59c","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"}],"refund_status":null,"scan_form":null,"selected_rate":{"id":"rate_a09383c500bc46588ed029fd44719843","object":"Rate","created_at":"2022-04-29T18:45:44Z","updated_at":"2022-04-29T18:45:44Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_54788167f5ff4560b7a96a04e912a59c","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},"tracker":{"id":"trk_2f4fc01bd53e4a42b0ad5a22b7414050","object":"Tracker","mode":"test","tracking_code":"9400100109361117183342","status":"unknown","status_detail":"unknown","created_at":"2022-04-29T18:45:44Z","updated_at":"2022-04-29T18:45:44Z","signed_by":null,"weight":null,"est_delivery_date":null,"shipment_id":"shp_54788167f5ff4560b7a96a04e912a59c","carrier":"USPS","tracking_details":[],"fees":[],"carrier_detail":null,"public_url":"https://track.easypost.com/djE6dHJrXzJmNGZjMDFiZDUzZTRhNDJiMGFkNWEyMmI3NDE0MDUw"},"to_address":{"id":"adr_93278ec3c7ec11ecbcc6ac1f6bc7bdc6","object":"Address","created_at":"2022-04-29T18:45:43+00:00","updated_at":"2022-04-29T18:45:43+00:00","name":"JACK
         SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN
-        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"usps_zone":1,"return_address":{"id":"adr_0c4dde30b9c611ec8319ac1f6b0a0d1e","object":"Address","created_at":"2022-04-11T18:34:40+00:00","updated_at":"2022-04-11T18:34:40+00:00","name":"Jack
+        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"usps_zone":1,"return_address":{"id":"adr_932941dac7ec11eca530ac1f6b0a0d1e","object":"Address","created_at":"2022-04-29T18:45:43+00:00","updated_at":"2022-04-29T18:45:43+00:00","name":"Jack
         Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_0c4b65a9b9c611ec9a53ac1f6bc72124","object":"Address","created_at":"2022-04-11T18:34:40+00:00","updated_at":"2022-04-11T18:34:40+00:00","name":"JACK
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_93278ec3c7ec11ecbcc6ac1f6bc7bdc6","object":"Address","created_at":"2022-04-29T18:45:43+00:00","updated_at":"2022-04-29T18:45:43+00:00","name":"JACK
         SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN
-        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"forms":[],"fees":[{"object":"Fee","type":"LabelFee","amount":"0.01000","charged":true,"refunded":false},{"object":"Fee","type":"PostageFee","amount":"5.49000","charged":true,"refunded":false}],"id":"shp_e2b8ec8d75c34627b07312b9ee9960d5","object":"Shipment"}'
-  recorded_at: Mon, 11 Apr 2022 18:34:41 GMT
+        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"forms":[],"fees":[{"object":"Fee","type":"LabelFee","amount":"0.01000","charged":true,"refunded":false},{"object":"Fee","type":"PostageFee","amount":"5.49000","charged":true,"refunded":false}],"id":"shp_54788167f5ff4560b7a96a04e912a59c","object":"Shipment"}'
+  recorded_at: Fri, 29 Apr 2022 18:45:44 GMT
 - request:
     method: post
     uri: https://api.easypost.com/v2/pickups
     body:
       encoding: UTF-8
       string: '{"pickup":{"address":{"name":"Jack Sparrow","company":"EasyPost","street1":"388
-        Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","phone":"5555555555"},"min_datetime":"2022-04-12","max_datetime":"2022-04-12","instructions":"Pickup
-        at front door","shipment":{"id":"shp_e2b8ec8d75c34627b07312b9ee9960d5"}}}'
+        Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","phone":"5555555555"},"min_datetime":"2022-05-01","max_datetime":"2022-05-01","instructions":"Pickup
+        at front door","shipment":{"id":"shp_54788167f5ff4560b7a96a04e912a59c"}}}'
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -113,7 +113,7 @@ http_interactions:
       Referrer-Policy:
       - strict-origin-when-cross-origin
       X-Ep-Request-Uuid:
-      - '0991fb57625474c1e786b3fa00232bce'
+      - e9f28f73626c3258e786bcc4004698a7
       Cache-Control:
       - no-cache, no-store
       Pragma:
@@ -123,27 +123,27 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"0b6dfb407aacc8340782af876814ff3c"
+      - W/"ee53ab258471cd4b09ec7de9e7775773"
       X-Runtime:
-      - '0.870326'
+      - '1.706057'
       Transfer-Encoding:
       - chunked
       X-Node:
-      - bigweb9nuq
+      - bigweb2nuq
       X-Version-Label:
-      - easypost-202204082123-da17cc1ac2-master
+      - easypost-202204282028-6188e715cb-master
       X-Backend:
       - easypost
       X-Proxied:
-      - extlb2nuq fde591f008
-      - intlb1nuq fde591f008
+      - extlb1nuq 5fac7c1107
+      - intlb2nuq fde591f008
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"pickup_a6c46b72370f4fa4b26295dda0c5b551","object":"Pickup","created_at":"2022-04-11T18:34:41Z","updated_at":"2022-04-11T18:34:41Z","mode":"test","status":"unknown","reference":null,"min_datetime":"2022-04-12T00:00:00Z","max_datetime":"2022-04-12T00:00:00Z","is_account_address":false,"instructions":"Pickup
-        at front door","messages":[],"confirmation":null,"address":{"id":"adr_0cff0edab9c611ec8820ac1f6bc7bdc6","object":"Address","created_at":"2022-04-11T18:34:41+00:00","updated_at":"2022-04-11T18:34:41+00:00","name":"Jack
+      string: '{"id":"pickup_628db967077847b9acd065e9d0bdff53","object":"Pickup","created_at":"2022-04-29T18:45:44Z","updated_at":"2022-04-29T18:45:44Z","mode":"test","status":"unknown","reference":null,"min_datetime":"2022-05-01T00:00:00Z","max_datetime":"2022-05-01T00:00:00Z","is_account_address":false,"instructions":"Pickup
+        at front door","messages":[],"confirmation":null,"address":{"id":"adr_93ceacbec7ec11ec8898ac1f6bc7b362","object":"Address","created_at":"2022-04-29T18:45:44+00:00","updated_at":"2022-04-29T18:45:44+00:00","name":"Jack
         Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"carrier_accounts":[],"pickup_rates":[{"mode":"test","service":"NextDay","rate":"0.00","currency":"USD","created_at":"2022-04-11T18:34:42Z","updated_at":"2022-04-11T18:34:42Z","carrier":"USPS","pickup_id":"pickup_a6c46b72370f4fa4b26295dda0c5b551","id":"pickuprate_f44de5d50bdc470b8c03f6be46646ab0","object":"PickupRate"}]}'
-  recorded_at: Mon, 11 Apr 2022 18:34:42 GMT
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"carrier_accounts":[],"pickup_rates":[{"mode":"test","service":"NextDay","rate":"0.00","currency":"USD","created_at":"2022-04-29T18:45:46Z","updated_at":"2022-04-29T18:45:46Z","carrier":"USPS","pickup_id":"pickup_628db967077847b9acd065e9d0bdff53","id":"pickuprate_1b6ae4e3e0eb4d53be70f2b825530237","object":"PickupRate"}]}'
+  recorded_at: Fri, 29 Apr 2022 18:45:46 GMT
 recorded_with: VCR 6.0.0

--- a/spec/cassettes/pickup/EasyPost_Pickup_lowest_rate_tests_various_usage_alterations_of_the_lowest_rate_method.yml
+++ b/spec/cassettes/pickup/EasyPost_Pickup_lowest_rate_tests_various_usage_alterations_of_the_lowest_rate_method.yml
@@ -1,0 +1,149 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.easypost.com/v2/shipments
+    body:
+      encoding: UTF-8
+      string: '{"shipment":{"to_address":{"name":"Jack Sparrow","company":"EasyPost","street1":"388
+        Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","phone":"5555555555"},"from_address":{"name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","phone":"5555555555"},"parcel":{"length":"10","width":"8","height":"4","weight":"15.4"},"service":"First","carrier_accounts":["ca_716f33fd9fd348238b85c2922237f98b"],"carrier":"USPS"}}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - EasyPost/v2 RubyClient/4.1.2 Ruby/3.1.1-p18
+      Content-Type:
+      - application/json
+      Authorization: "<AUTHORIZATION>"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      X-Ep-Request-Uuid:
+      - e9f28f73626c3266e786bd0100469e56
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Location:
+      - "/api/v2/shipments/shp_a407a8e7a65f4001a21b39664d412609"
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"244f86754fb4db85a04dbce4edc2c6ab"
+      X-Runtime:
+      - '0.917136'
+      Transfer-Encoding:
+      - chunked
+      X-Node:
+      - bigweb5nuq
+      X-Version-Label:
+      - easypost-202204282028-6188e715cb-master
+      X-Backend:
+      - easypost
+      X-Proxied:
+      - extlb1nuq 5fac7c1107
+      - intlb1nuq fde591f008
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: '{"created_at":"2022-04-29T18:45:58Z","is_return":false,"messages":[],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":"9400100109361117183397","updated_at":"2022-04-29T18:45:59Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_9bddcdf9c7ec11ec8b8aac1f6bc7b362","object":"Address","created_at":"2022-04-29T18:45:58+00:00","updated_at":"2022-04-29T18:45:58+00:00","name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_bbf96056940c4a828d8f8c07abce3a5f","object":"Parcel","created_at":"2022-04-29T18:45:58Z","updated_at":"2022-04-29T18:45:58Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":{"object":"PostageLabel","id":"pl_f47b1121b40d49d0a95216c505723582","created_at":"2022-04-29T18:45:58Z","updated_at":"2022-04-29T18:45:58Z","date_advance":0,"integrated_form":"none","label_date":"2022-04-29T18:45:58Z","label_resolution":300,"label_size":"4x6","label_type":"default","label_file_type":"image/png","label_url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220429/a7d2a7f7306c4511b06178439263040c.png","label_pdf_url":null,"label_zpl_url":null,"label_epl2_url":null,"label_file":null},"rates":[{"id":"rate_2fbbbfd8079346189e34764412d6ae95","object":"Rate","created_at":"2022-04-29T18:45:58Z","updated_at":"2022-04-29T18:45:58Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_a407a8e7a65f4001a21b39664d412609","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},{"id":"rate_77530dd3f82248b78fa7c77c6991d14d","object":"Rate","created_at":"2022-04-29T18:45:58Z","updated_at":"2022-04-29T18:45:58Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_a407a8e7a65f4001a21b39664d412609","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},{"id":"rate_cdc824457e4043b9a1f4b73cf12fc760","object":"Rate","created_at":"2022-04-29T18:45:58Z","updated_at":"2022-04-29T18:45:58Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_a407a8e7a65f4001a21b39664d412609","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},{"id":"rate_6ab1ec628860474f83178d701b48d6de","object":"Rate","created_at":"2022-04-29T18:45:58Z","updated_at":"2022-04-29T18:45:58Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_a407a8e7a65f4001a21b39664d412609","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"}],"refund_status":null,"scan_form":null,"selected_rate":{"id":"rate_77530dd3f82248b78fa7c77c6991d14d","object":"Rate","created_at":"2022-04-29T18:45:58Z","updated_at":"2022-04-29T18:45:58Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_a407a8e7a65f4001a21b39664d412609","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},"tracker":{"id":"trk_6cfbbd58c956432d8ef2afdc9995482a","object":"Tracker","mode":"test","tracking_code":"9400100109361117183397","status":"unknown","status_detail":"unknown","created_at":"2022-04-29T18:45:59Z","updated_at":"2022-04-29T18:45:59Z","signed_by":null,"weight":null,"est_delivery_date":null,"shipment_id":"shp_a407a8e7a65f4001a21b39664d412609","carrier":"USPS","tracking_details":[],"fees":[],"carrier_detail":null,"public_url":"https://track.easypost.com/djE6dHJrXzZjZmJiZDU4Yzk1NjQzMmQ4ZWYyYWZkYzk5OTU0ODJh"},"to_address":{"id":"adr_9bdbb1bbc7ec11eca855ac1f6b0a0d1e","object":"Address","created_at":"2022-04-29T18:45:58+00:00","updated_at":"2022-04-29T18:45:58+00:00","name":"JACK
+        SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN
+        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"usps_zone":1,"return_address":{"id":"adr_9bddcdf9c7ec11ec8b8aac1f6bc7b362","object":"Address","created_at":"2022-04-29T18:45:58+00:00","updated_at":"2022-04-29T18:45:58+00:00","name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_9bdbb1bbc7ec11eca855ac1f6b0a0d1e","object":"Address","created_at":"2022-04-29T18:45:58+00:00","updated_at":"2022-04-29T18:45:58+00:00","name":"JACK
+        SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN
+        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"forms":[],"fees":[{"object":"Fee","type":"LabelFee","amount":"0.01000","charged":true,"refunded":false},{"object":"Fee","type":"PostageFee","amount":"5.49000","charged":true,"refunded":false}],"id":"shp_a407a8e7a65f4001a21b39664d412609","object":"Shipment"}'
+  recorded_at: Fri, 29 Apr 2022 18:45:59 GMT
+- request:
+    method: post
+    uri: https://api.easypost.com/v2/pickups
+    body:
+      encoding: UTF-8
+      string: '{"pickup":{"address":{"name":"Jack Sparrow","company":"EasyPost","street1":"388
+        Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","phone":"5555555555"},"min_datetime":"2022-05-01","max_datetime":"2022-05-01","instructions":"Pickup
+        at front door","shipment":{"id":"shp_a407a8e7a65f4001a21b39664d412609"}}}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - EasyPost/v2 RubyClient/4.1.2 Ruby/3.1.1-p18
+      Content-Type:
+      - application/json
+      Authorization: "<AUTHORIZATION>"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      X-Ep-Request-Uuid:
+      - e9f28f73626c3267e786bd0200469ed3
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"ef0ec524107c5cefbc5c371b1026bee2"
+      X-Runtime:
+      - '0.833998'
+      Transfer-Encoding:
+      - chunked
+      X-Node:
+      - bigweb9nuq
+      X-Version-Label:
+      - easypost-202204282028-6188e715cb-master
+      X-Backend:
+      - easypost
+      X-Proxied:
+      - extlb1nuq 5fac7c1107
+      - intlb1nuq fde591f008
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"pickup_0f807ac1e3a44740aee59eb82765126a","object":"Pickup","created_at":"2022-04-29T18:45:59Z","updated_at":"2022-04-29T18:45:59Z","mode":"test","status":"unknown","reference":null,"min_datetime":"2022-05-01T00:00:00Z","max_datetime":"2022-05-01T00:00:00Z","is_account_address":false,"instructions":"Pickup
+        at front door","messages":[],"confirmation":null,"address":{"id":"adr_9c97bc44c7ec11eca89dac1f6b0a0d1e","object":"Address","created_at":"2022-04-29T18:45:59+00:00","updated_at":"2022-04-29T18:45:59+00:00","name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"carrier_accounts":[],"pickup_rates":[{"mode":"test","service":"NextDay","rate":"0.00","currency":"USD","created_at":"2022-04-29T18:46:00Z","updated_at":"2022-04-29T18:46:00Z","carrier":"USPS","pickup_id":"pickup_0f807ac1e3a44740aee59eb82765126a","id":"pickuprate_f871f9ebb0734dfca3a7086dcf71503f","object":"PickupRate"}]}'
+  recorded_at: Fri, 29 Apr 2022 18:46:00 GMT
+recorded_with: VCR 6.0.0

--- a/spec/cassettes/pickup/EasyPost_Pickup_retrieve_retrieves_a_pickup.yml
+++ b/spec/cassettes/pickup/EasyPost_Pickup_retrieve_retrieves_a_pickup.yml
@@ -37,7 +37,7 @@ http_interactions:
       Referrer-Policy:
       - strict-origin-when-cross-origin
       X-Ep-Request-Uuid:
-      - '0991fb52625474c2e786b3fb00232c44'
+      - e9f28f73626c325ae786bcc50046997b
       Cache-Control:
       - no-cache, no-store
       Pragma:
@@ -45,48 +45,46 @@ http_interactions:
       Expires:
       - '0'
       Location:
-      - "/api/v2/shipments/shp_ba4dd2362746421fa08fdd684d462e0b"
+      - "/api/v2/shipments/shp_97d7b57254a64786bc4a894d2aa4e7ec"
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"70c5df7660c966c5ed8df3e08bc46de3"
+      - W/"a4932d2bac10bb54a50be50b7781298e"
       X-Runtime:
-      - '0.906490'
+      - '0.872581'
       Transfer-Encoding:
       - chunked
       X-Node:
-      - bigweb7nuq
+      - bigweb5nuq
       X-Version-Label:
-      - easypost-202204082123-da17cc1ac2-master
+      - easypost-202204282028-6188e715cb-master
       X-Backend:
       - easypost
-      X-Canary:
-      - direct
       X-Proxied:
-      - extlb2nuq fde591f008
-      - intlb2nuq fde591f008
+      - extlb1nuq 5fac7c1107
+      - intlb1nuq fde591f008
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
     body:
       encoding: ASCII-8BIT
-      string: '{"created_at":"2022-04-11T18:34:42Z","is_return":false,"messages":[],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":"9400100109361114522106","updated_at":"2022-04-11T18:34:43Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_0dbd44c3b9c611ec8256ac1f6bc7b362","object":"Address","created_at":"2022-04-11T18:34:42+00:00","updated_at":"2022-04-11T18:34:42+00:00","name":"Jack
+      string: '{"created_at":"2022-04-29T18:45:46Z","is_return":false,"messages":[],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":"9400100109361117183359","updated_at":"2022-04-29T18:45:47Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_94ead1a6c7ec11eca5d9ac1f6b0a0d1e","object":"Address","created_at":"2022-04-29T18:45:46+00:00","updated_at":"2022-04-29T18:45:46+00:00","name":"Jack
         Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_38365319ab524dc4b28dedcbed36fe1a","object":"Parcel","created_at":"2022-04-11T18:34:42Z","updated_at":"2022-04-11T18:34:42Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":{"object":"PostageLabel","id":"pl_ba63f124ccbd4a8a96d2743362c9c823","created_at":"2022-04-11T18:34:43Z","updated_at":"2022-04-11T18:34:43Z","date_advance":0,"integrated_form":"none","label_date":"2022-04-11T18:34:43Z","label_resolution":300,"label_size":"4x6","label_type":"default","label_file_type":"image/png","label_url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220411/54581279a142444b9eb598f998064bf1.png","label_pdf_url":null,"label_zpl_url":null,"label_epl2_url":null,"label_file":null},"rates":[{"id":"rate_16f77c6decc04cc69be1e354d35a5fda","object":"Rate","created_at":"2022-04-11T18:34:42Z","updated_at":"2022-04-11T18:34:42Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_ba4dd2362746421fa08fdd684d462e0b","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},{"id":"rate_2bbcaedfeb4f42e785cd5a9db02d5af0","object":"Rate","created_at":"2022-04-11T18:34:42Z","updated_at":"2022-04-11T18:34:42Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_ba4dd2362746421fa08fdd684d462e0b","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},{"id":"rate_3e7caa16334b4170931e679a17b115de","object":"Rate","created_at":"2022-04-11T18:34:42Z","updated_at":"2022-04-11T18:34:42Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_ba4dd2362746421fa08fdd684d462e0b","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},{"id":"rate_a761af27158a4960ac498402c2fd21b2","object":"Rate","created_at":"2022-04-11T18:34:42Z","updated_at":"2022-04-11T18:34:42Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_ba4dd2362746421fa08fdd684d462e0b","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"}],"refund_status":null,"scan_form":null,"selected_rate":{"id":"rate_2bbcaedfeb4f42e785cd5a9db02d5af0","object":"Rate","created_at":"2022-04-11T18:34:43Z","updated_at":"2022-04-11T18:34:43Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_ba4dd2362746421fa08fdd684d462e0b","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},"tracker":{"id":"trk_2de7f823ba30498bae1b98db2686ca43","object":"Tracker","mode":"test","tracking_code":"9400100109361114522106","status":"unknown","status_detail":"unknown","created_at":"2022-04-11T18:34:43Z","updated_at":"2022-04-11T18:34:43Z","signed_by":null,"weight":null,"est_delivery_date":null,"shipment_id":"shp_ba4dd2362746421fa08fdd684d462e0b","carrier":"USPS","tracking_details":[],"fees":[],"carrier_detail":null,"public_url":"https://track.easypost.com/djE6dHJrXzJkZTdmODIzYmEzMDQ5OGJhZTFiOThkYjI2ODZjYTQz"},"to_address":{"id":"adr_0dbb97e2b9c611ec8254ac1f6bc7b362","object":"Address","created_at":"2022-04-11T18:34:42+00:00","updated_at":"2022-04-11T18:34:42+00:00","name":"JACK
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_f372be1fb50047188de1a1bc09455af4","object":"Parcel","created_at":"2022-04-29T18:45:46Z","updated_at":"2022-04-29T18:45:46Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":{"object":"PostageLabel","id":"pl_451aa41b3cc44c03a986adb41c0e5818","created_at":"2022-04-29T18:45:47Z","updated_at":"2022-04-29T18:45:47Z","date_advance":0,"integrated_form":"none","label_date":"2022-04-29T18:45:47Z","label_resolution":300,"label_size":"4x6","label_type":"default","label_file_type":"image/png","label_url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220429/e6af52746e76483e9ccd21aa0ae49928.png","label_pdf_url":null,"label_zpl_url":null,"label_epl2_url":null,"label_file":null},"rates":[{"id":"rate_61e76a24f9cd4e18b9559d008631737e","object":"Rate","created_at":"2022-04-29T18:45:46Z","updated_at":"2022-04-29T18:45:46Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_97d7b57254a64786bc4a894d2aa4e7ec","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},{"id":"rate_d24a91bbc8004bafa9cc199440691490","object":"Rate","created_at":"2022-04-29T18:45:46Z","updated_at":"2022-04-29T18:45:46Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_97d7b57254a64786bc4a894d2aa4e7ec","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},{"id":"rate_af4d60a2e5924d009e29f407312d3ba3","object":"Rate","created_at":"2022-04-29T18:45:46Z","updated_at":"2022-04-29T18:45:46Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_97d7b57254a64786bc4a894d2aa4e7ec","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},{"id":"rate_14850ceb449146da90e253cf79db24c1","object":"Rate","created_at":"2022-04-29T18:45:46Z","updated_at":"2022-04-29T18:45:46Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_97d7b57254a64786bc4a894d2aa4e7ec","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"}],"refund_status":null,"scan_form":null,"selected_rate":{"id":"rate_d24a91bbc8004bafa9cc199440691490","object":"Rate","created_at":"2022-04-29T18:45:47Z","updated_at":"2022-04-29T18:45:47Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_97d7b57254a64786bc4a894d2aa4e7ec","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},"tracker":{"id":"trk_a86ec4167e2c454e8bf73203be90b718","object":"Tracker","mode":"test","tracking_code":"9400100109361117183359","status":"unknown","status_detail":"unknown","created_at":"2022-04-29T18:45:47Z","updated_at":"2022-04-29T18:45:47Z","signed_by":null,"weight":null,"est_delivery_date":null,"shipment_id":"shp_97d7b57254a64786bc4a894d2aa4e7ec","carrier":"USPS","tracking_details":[],"fees":[],"carrier_detail":null,"public_url":"https://track.easypost.com/djE6dHJrX2E4NmVjNDE2N2UyYzQ1NGU4YmY3MzIwM2JlOTBiNzE4"},"to_address":{"id":"adr_94e92230c7ec11ec88feac1f6bc7b362","object":"Address","created_at":"2022-04-29T18:45:46+00:00","updated_at":"2022-04-29T18:45:46+00:00","name":"JACK
         SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN
-        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"usps_zone":1,"return_address":{"id":"adr_0dbd44c3b9c611ec8256ac1f6bc7b362","object":"Address","created_at":"2022-04-11T18:34:42+00:00","updated_at":"2022-04-11T18:34:42+00:00","name":"Jack
+        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"usps_zone":1,"return_address":{"id":"adr_94ead1a6c7ec11eca5d9ac1f6b0a0d1e","object":"Address","created_at":"2022-04-29T18:45:46+00:00","updated_at":"2022-04-29T18:45:46+00:00","name":"Jack
         Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_0dbb97e2b9c611ec8254ac1f6bc7b362","object":"Address","created_at":"2022-04-11T18:34:42+00:00","updated_at":"2022-04-11T18:34:42+00:00","name":"JACK
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_94e92230c7ec11ec88feac1f6bc7b362","object":"Address","created_at":"2022-04-29T18:45:46+00:00","updated_at":"2022-04-29T18:45:46+00:00","name":"JACK
         SPARROW","company":"EASYPOST","street1":"388 TOWNSEND ST APT 20","street2":null,"city":"SAN
-        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"forms":[],"fees":[{"object":"Fee","type":"LabelFee","amount":"0.01000","charged":true,"refunded":false},{"object":"Fee","type":"PostageFee","amount":"5.49000","charged":true,"refunded":false}],"id":"shp_ba4dd2362746421fa08fdd684d462e0b","object":"Shipment"}'
-  recorded_at: Mon, 11 Apr 2022 18:34:43 GMT
+        FRANCISCO","state":"CA","zip":"94107-1670","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":true,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":37.77551,"longitude":-122.39697,"time_zone":"America/Los_Angeles"}}}},"forms":[],"fees":[{"object":"Fee","type":"LabelFee","amount":"0.01000","charged":true,"refunded":false},{"object":"Fee","type":"PostageFee","amount":"5.49000","charged":true,"refunded":false}],"id":"shp_97d7b57254a64786bc4a894d2aa4e7ec","object":"Shipment"}'
+  recorded_at: Fri, 29 Apr 2022 18:45:47 GMT
 - request:
     method: post
     uri: https://api.easypost.com/v2/pickups
     body:
       encoding: UTF-8
       string: '{"pickup":{"address":{"name":"Jack Sparrow","company":"EasyPost","street1":"388
-        Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","phone":"5555555555"},"min_datetime":"2022-04-12","max_datetime":"2022-04-12","instructions":"Pickup
-        at front door","shipment":{"id":"shp_ba4dd2362746421fa08fdd684d462e0b"}}}'
+        Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","phone":"5555555555"},"min_datetime":"2022-05-01","max_datetime":"2022-05-01","instructions":"Pickup
+        at front door","shipment":{"id":"shp_97d7b57254a64786bc4a894d2aa4e7ec"}}}'
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -115,7 +113,7 @@ http_interactions:
       Referrer-Policy:
       - strict-origin-when-cross-origin
       X-Ep-Request-Uuid:
-      - '0991fb55625474c3e786b3fc00232ce3'
+      - e9f28f79626c325be786bcc6004699e9
       Cache-Control:
       - no-cache, no-store
       Pragma:
@@ -125,32 +123,32 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"d6555a3dfb2b69827eb36e9bf1b3c6db"
+      - W/"5726992eaeaedad2a2be88bc610b61a3"
       X-Runtime:
-      - '1.010372'
+      - '0.732031'
       Transfer-Encoding:
       - chunked
       X-Node:
-      - bigweb3nuq
+      - bigweb1nuq
       X-Version-Label:
-      - easypost-202204082123-da17cc1ac2-master
+      - easypost-202204282028-6188e715cb-master
       X-Backend:
       - easypost
       X-Proxied:
-      - extlb2nuq fde591f008
+      - extlb1nuq 5fac7c1107
       - intlb1nuq fde591f008
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"pickup_80b72d338fb24b9faa382ffabb645033","object":"Pickup","created_at":"2022-04-11T18:34:43Z","updated_at":"2022-04-11T18:34:43Z","mode":"test","status":"unknown","reference":null,"min_datetime":"2022-04-12T00:00:00Z","max_datetime":"2022-04-12T00:00:00Z","is_account_address":false,"instructions":"Pickup
-        at front door","messages":[],"confirmation":null,"address":{"id":"adr_0e63d529b9c611ec8295ac1f6bc7b362","object":"Address","created_at":"2022-04-11T18:34:43+00:00","updated_at":"2022-04-11T18:34:43+00:00","name":"Jack
+      string: '{"id":"pickup_516a68e17ac34c6fb540ce9539cec8ec","object":"Pickup","created_at":"2022-04-29T18:45:47Z","updated_at":"2022-04-29T18:45:47Z","mode":"test","status":"unknown","reference":null,"min_datetime":"2022-05-01T00:00:00Z","max_datetime":"2022-05-01T00:00:00Z","is_account_address":false,"instructions":"Pickup
+        at front door","messages":[],"confirmation":null,"address":{"id":"adr_958d631ec7ec11ecbd5bac1f6bc7bdc6","object":"Address","created_at":"2022-04-29T18:45:47+00:00","updated_at":"2022-04-29T18:45:47+00:00","name":"Jack
         Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"carrier_accounts":[],"pickup_rates":[{"mode":"test","service":"NextDay","rate":"0.00","currency":"USD","created_at":"2022-04-11T18:34:44Z","updated_at":"2022-04-11T18:34:44Z","carrier":"USPS","pickup_id":"pickup_80b72d338fb24b9faa382ffabb645033","id":"pickuprate_cd1043d803d5450484ba46102f168f2b","object":"PickupRate"}]}'
-  recorded_at: Mon, 11 Apr 2022 18:34:44 GMT
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"carrier_accounts":[],"pickup_rates":[{"mode":"test","service":"NextDay","rate":"0.00","currency":"USD","created_at":"2022-04-29T18:45:48Z","updated_at":"2022-04-29T18:45:48Z","carrier":"USPS","pickup_id":"pickup_516a68e17ac34c6fb540ce9539cec8ec","id":"pickuprate_918aece360a646d288846415ccd4d52d","object":"PickupRate"}]}'
+  recorded_at: Fri, 29 Apr 2022 18:45:48 GMT
 - request:
     method: get
-    uri: https://api.easypost.com/v2/pickups/pickup_80b72d338fb24b9faa382ffabb645033
+    uri: https://api.easypost.com/v2/pickups/pickup_516a68e17ac34c6fb540ce9539cec8ec
     body:
       encoding: US-ASCII
       string: ''
@@ -182,7 +180,7 @@ http_interactions:
       Referrer-Policy:
       - strict-origin-when-cross-origin
       X-Ep-Request-Uuid:
-      - '0991fb57625474c4e786b3fd00232d62'
+      - e9f28f74626c325ce786bcde00469a3e
       Cache-Control:
       - no-cache, no-store
       Pragma:
@@ -192,27 +190,27 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"d6555a3dfb2b69827eb36e9bf1b3c6db"
+      - W/"5726992eaeaedad2a2be88bc610b61a3"
       X-Runtime:
-      - '0.087458'
+      - '0.071733'
       Transfer-Encoding:
       - chunked
       X-Node:
-      - bigweb8nuq
+      - bigweb3nuq
       X-Version-Label:
-      - easypost-202204082123-da17cc1ac2-master
+      - easypost-202204282028-6188e715cb-master
       X-Backend:
       - easypost
       X-Proxied:
-      - extlb2nuq fde591f008
+      - extlb1nuq 5fac7c1107
       - intlb2nuq fde591f008
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"pickup_80b72d338fb24b9faa382ffabb645033","object":"Pickup","created_at":"2022-04-11T18:34:43Z","updated_at":"2022-04-11T18:34:43Z","mode":"test","status":"unknown","reference":null,"min_datetime":"2022-04-12T00:00:00Z","max_datetime":"2022-04-12T00:00:00Z","is_account_address":false,"instructions":"Pickup
-        at front door","messages":[],"confirmation":null,"address":{"id":"adr_0e63d529b9c611ec8295ac1f6bc7b362","object":"Address","created_at":"2022-04-11T18:34:43+00:00","updated_at":"2022-04-11T18:34:43+00:00","name":"Jack
+      string: '{"id":"pickup_516a68e17ac34c6fb540ce9539cec8ec","object":"Pickup","created_at":"2022-04-29T18:45:47Z","updated_at":"2022-04-29T18:45:47Z","mode":"test","status":"unknown","reference":null,"min_datetime":"2022-05-01T00:00:00Z","max_datetime":"2022-05-01T00:00:00Z","is_account_address":false,"instructions":"Pickup
+        at front door","messages":[],"confirmation":null,"address":{"id":"adr_958d631ec7ec11ecbd5bac1f6bc7bdc6","object":"Address","created_at":"2022-04-29T18:45:47+00:00","updated_at":"2022-04-29T18:45:47+00:00","name":"Jack
         Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
-        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"carrier_accounts":[],"pickup_rates":[{"mode":"test","service":"NextDay","rate":"0.00","currency":"USD","created_at":"2022-04-11T18:34:44Z","updated_at":"2022-04-11T18:34:44Z","carrier":"USPS","pickup_id":"pickup_80b72d338fb24b9faa382ffabb645033","id":"pickuprate_cd1043d803d5450484ba46102f168f2b","object":"PickupRate"}]}'
-  recorded_at: Mon, 11 Apr 2022 18:34:45 GMT
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"carrier_accounts":[],"pickup_rates":[{"mode":"test","service":"NextDay","rate":"0.00","currency":"USD","created_at":"2022-04-29T18:45:48Z","updated_at":"2022-04-29T18:45:48Z","carrier":"USPS","pickup_id":"pickup_516a68e17ac34c6fb540ce9539cec8ec","id":"pickuprate_918aece360a646d288846415ccd4d52d","object":"PickupRate"}]}'
+  recorded_at: Fri, 29 Apr 2022 18:45:48 GMT
 recorded_with: VCR 6.0.0

--- a/spec/cassettes/shipment/EasyPost_Shipment_get_lowest_smartrate_gets_the_lowest_smartrate_from_a_list_of_smartrates.yml
+++ b/spec/cassettes/shipment/EasyPost_Shipment_get_lowest_smartrate_gets_the_lowest_smartrate_from_a_list_of_smartrates.yml
@@ -1,0 +1,144 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.easypost.com/v2/shipments
+    body:
+      encoding: UTF-8
+      string: '{"shipment":{"to_address":{"name":"Jack Sparrow","company":"EasyPost","street1":"388
+        Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","phone":"5555555555"},"from_address":{"name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","phone":"5555555555"},"parcel":{"length":"10","width":"8","height":"4","weight":"15.4"}}}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - EasyPost/v2 RubyClient/4.1.2 Ruby/3.1.1-p18
+      Content-Type:
+      - application/json
+      Authorization: "<AUTHORIZATION>"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      X-Ep-Request-Uuid:
+      - b1df9427626c4700e787403e00503374
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Location:
+      - "/api/v2/shipments/shp_f268a55c20be4682ae88a85e15601903"
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"8f0d339c21dc9de920b09f4ba3e4c240"
+      X-Runtime:
+      - '0.198227'
+      Transfer-Encoding:
+      - chunked
+      X-Node:
+      - bigweb2nuq
+      X-Version-Label:
+      - easypost-202204282028-6188e715cb-master
+      X-Backend:
+      - easypost
+      X-Proxied:
+      - extlb2nuq 5fac7c1107
+      - intlb2nuq fde591f008
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: '{"created_at":"2022-04-29T20:13:52Z","is_return":false,"messages":[],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":null,"updated_at":"2022-04-29T20:13:52Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_e39c9c47c7f811ec91b3ac1f6b0a0d1e","object":"Address","created_at":"2022-04-29T20:13:52+00:00","updated_at":"2022-04-29T20:13:52+00:00","name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_66f67962ec9f412e901a6f2d578e5412","object":"Parcel","created_at":"2022-04-29T20:13:52Z","updated_at":"2022-04-29T20:13:52Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":null,"rates":[{"id":"rate_0741aaa8b46a41aeae1bb9f81f019010","object":"Rate","created_at":"2022-04-29T20:13:52Z","updated_at":"2022-04-29T20:13:52Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_f268a55c20be4682ae88a85e15601903","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},{"id":"rate_56d7c8a3451a4e048a13c280e7981083","object":"Rate","created_at":"2022-04-29T20:13:52Z","updated_at":"2022-04-29T20:13:52Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_f268a55c20be4682ae88a85e15601903","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},{"id":"rate_b589ff7e30654d28905664c90997151a","object":"Rate","created_at":"2022-04-29T20:13:52Z","updated_at":"2022-04-29T20:13:52Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_f268a55c20be4682ae88a85e15601903","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},{"id":"rate_5fa608eb726745f19a10bcabb7de6079","object":"Rate","created_at":"2022-04-29T20:13:52Z","updated_at":"2022-04-29T20:13:52Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_f268a55c20be4682ae88a85e15601903","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"}],"refund_status":null,"scan_form":null,"selected_rate":null,"tracker":null,"to_address":{"id":"adr_e39acd34c7f811ecb323ac1f6bc7bdc6","object":"Address","created_at":"2022-04-29T20:13:52+00:00","updated_at":"2022-04-29T20:13:52+00:00","name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"usps_zone":1,"return_address":{"id":"adr_e39c9c47c7f811ec91b3ac1f6b0a0d1e","object":"Address","created_at":"2022-04-29T20:13:52+00:00","updated_at":"2022-04-29T20:13:52+00:00","name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_e39acd34c7f811ecb323ac1f6bc7bdc6","object":"Address","created_at":"2022-04-29T20:13:52+00:00","updated_at":"2022-04-29T20:13:52+00:00","name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"forms":[],"fees":[],"id":"shp_f268a55c20be4682ae88a85e15601903","object":"Shipment"}'
+  recorded_at: Fri, 29 Apr 2022 20:13:52 GMT
+- request:
+    method: get
+    uri: https://api.easypost.com/v2/shipments/shp_f268a55c20be4682ae88a85e15601903/smartrate
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - EasyPost/v2 RubyClient/4.1.2 Ruby/3.1.1-p18
+      Content-Type:
+      - application/json
+      Authorization: "<AUTHORIZATION>"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      X-Ep-Request-Uuid:
+      - b1df9425626c4700e787403f005033a7
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"edb8a5f292e1d4b838ba12e2490c4177"
+      X-Runtime:
+      - '0.069536'
+      Transfer-Encoding:
+      - chunked
+      X-Node:
+      - bigweb6nuq
+      X-Version-Label:
+      - easypost-202204282028-6188e715cb-master
+      X-Backend:
+      - easypost
+      X-Proxied:
+      - extlb2nuq 5fac7c1107
+      - intlb2nuq fde591f008
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: '{"result":[{"carrier":"USPS","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b","created_at":"2022-04-29T20:13:52Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":1,"est_delivery_days":1,"id":"rate_0741aaa8b46a41aeae1bb9f81f019010","list_currency":"USD","list_rate":7.37,"mode":"test","object":"Rate","rate":7.37,"retail_currency":"USD","retail_rate":8.7,"service":"Priority","shipment_id":"shp_f268a55c20be4682ae88a85e15601903","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":1,"percentile_95":2,"percentile_97":2,"percentile_99":4},"updated_at":"2022-04-29T20:13:52Z"},{"carrier":"USPS","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b","created_at":"2022-04-29T20:13:52Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":2,"est_delivery_days":2,"id":"rate_56d7c8a3451a4e048a13c280e7981083","list_currency":"USD","list_rate":5.49,"mode":"test","object":"Rate","rate":5.49,"retail_currency":"USD","retail_rate":5.49,"service":"First","shipment_id":"shp_f268a55c20be4682ae88a85e15601903","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":2,"percentile_95":2,"percentile_97":2,"percentile_99":3},"updated_at":"2022-04-29T20:13:52Z"},{"carrier":"USPS","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b","created_at":"2022-04-29T20:13:52Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":2,"est_delivery_days":2,"id":"rate_b589ff7e30654d28905664c90997151a","list_currency":"USD","list_rate":7.22,"mode":"test","object":"Rate","rate":7.22,"retail_currency":"USD","retail_rate":7.22,"service":"ParcelSelect","shipment_id":"shp_f268a55c20be4682ae88a85e15601903","time_in_transit":{"percentile_50":1,"percentile_75":2,"percentile_85":3,"percentile_90":4,"percentile_95":4,"percentile_97":5,"percentile_99":7},"updated_at":"2022-04-29T20:13:52Z"},{"carrier":"USPS","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b","created_at":"2022-04-29T20:13:52Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":null,"est_delivery_days":null,"id":"rate_5fa608eb726745f19a10bcabb7de6079","list_currency":"USD","list_rate":23.75,"mode":"test","object":"Rate","rate":23.75,"retail_currency":"USD","retail_rate":27.4,"service":"Express","shipment_id":"shp_f268a55c20be4682ae88a85e15601903","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":1,"percentile_95":2,"percentile_97":2,"percentile_99":4},"updated_at":"2022-04-29T20:13:52Z"}]}'
+  recorded_at: Fri, 29 Apr 2022 20:13:52 GMT
+recorded_with: VCR 6.0.0

--- a/spec/cassettes/shipment/EasyPost_Shipment_get_lowest_smartrate_raises_an_error_when_no_rates_are_found_due_to_delivery_accuracy.yml
+++ b/spec/cassettes/shipment/EasyPost_Shipment_get_lowest_smartrate_raises_an_error_when_no_rates_are_found_due_to_delivery_accuracy.yml
@@ -1,0 +1,144 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.easypost.com/v2/shipments
+    body:
+      encoding: UTF-8
+      string: '{"shipment":{"to_address":{"name":"Jack Sparrow","company":"EasyPost","street1":"388
+        Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","phone":"5555555555"},"from_address":{"name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","phone":"5555555555"},"parcel":{"length":"10","width":"8","height":"4","weight":"15.4"}}}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - EasyPost/v2 RubyClient/4.1.2 Ruby/3.1.1-p18
+      Content-Type:
+      - application/json
+      Authorization: "<AUTHORIZATION>"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      X-Ep-Request-Uuid:
+      - b1df9426626c4701e78740420050340f
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Location:
+      - "/api/v2/shipments/shp_f1995fdbb0ed41d0ad3152436148bce9"
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"047b11ff408644b1bd2bf83a3fb664a8"
+      X-Runtime:
+      - '0.209627'
+      Transfer-Encoding:
+      - chunked
+      X-Node:
+      - bigweb4nuq
+      X-Version-Label:
+      - easypost-202204282028-6188e715cb-master
+      X-Backend:
+      - easypost
+      X-Proxied:
+      - extlb2nuq 5fac7c1107
+      - intlb2nuq fde591f008
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: '{"created_at":"2022-04-29T20:13:53Z","is_return":false,"messages":[],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":null,"updated_at":"2022-04-29T20:13:53Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_e45e080fc7f811ec91e1ac1f6b0a0d1e","object":"Address","created_at":"2022-04-29T20:13:53+00:00","updated_at":"2022-04-29T20:13:53+00:00","name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_6969230ed49244608d3f0f6866881f6a","object":"Parcel","created_at":"2022-04-29T20:13:53Z","updated_at":"2022-04-29T20:13:53Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":null,"rates":[{"id":"rate_198a9d2695d1464eabc54a2c6bf2d574","object":"Rate","created_at":"2022-04-29T20:13:54Z","updated_at":"2022-04-29T20:13:54Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_f1995fdbb0ed41d0ad3152436148bce9","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},{"id":"rate_b84f8100c8f042a2878384afc3e8241e","object":"Rate","created_at":"2022-04-29T20:13:54Z","updated_at":"2022-04-29T20:13:54Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_f1995fdbb0ed41d0ad3152436148bce9","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},{"id":"rate_77def4f15869406db566c7317ad6036b","object":"Rate","created_at":"2022-04-29T20:13:54Z","updated_at":"2022-04-29T20:13:54Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_f1995fdbb0ed41d0ad3152436148bce9","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},{"id":"rate_b20e2f0b65ba4803be40817f3422b1e9","object":"Rate","created_at":"2022-04-29T20:13:54Z","updated_at":"2022-04-29T20:13:54Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_f1995fdbb0ed41d0ad3152436148bce9","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"}],"refund_status":null,"scan_form":null,"selected_rate":null,"tracker":null,"to_address":{"id":"adr_e45c3178c7f811ec91e0ac1f6b0a0d1e","object":"Address","created_at":"2022-04-29T20:13:53+00:00","updated_at":"2022-04-29T20:13:53+00:00","name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"usps_zone":1,"return_address":{"id":"adr_e45e080fc7f811ec91e1ac1f6b0a0d1e","object":"Address","created_at":"2022-04-29T20:13:53+00:00","updated_at":"2022-04-29T20:13:53+00:00","name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_e45c3178c7f811ec91e0ac1f6b0a0d1e","object":"Address","created_at":"2022-04-29T20:13:53+00:00","updated_at":"2022-04-29T20:13:53+00:00","name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"forms":[],"fees":[],"id":"shp_f1995fdbb0ed41d0ad3152436148bce9","object":"Shipment"}'
+  recorded_at: Fri, 29 Apr 2022 20:13:54 GMT
+- request:
+    method: get
+    uri: https://api.easypost.com/v2/shipments/shp_f1995fdbb0ed41d0ad3152436148bce9/smartrate
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - EasyPost/v2 RubyClient/4.1.2 Ruby/3.1.1-p18
+      Content-Type:
+      - application/json
+      Authorization: "<AUTHORIZATION>"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      X-Ep-Request-Uuid:
+      - b1df942a626c4702e787405a0050343d
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"5cfc0838036e351ced20783c077b18a0"
+      X-Runtime:
+      - '0.067438'
+      Transfer-Encoding:
+      - chunked
+      X-Node:
+      - bigweb5nuq
+      X-Version-Label:
+      - easypost-202204282028-6188e715cb-master
+      X-Backend:
+      - easypost
+      X-Proxied:
+      - extlb2nuq 5fac7c1107
+      - intlb1nuq fde591f008
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: '{"result":[{"carrier":"USPS","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b","created_at":"2022-04-29T20:13:54Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":2,"est_delivery_days":2,"id":"rate_198a9d2695d1464eabc54a2c6bf2d574","list_currency":"USD","list_rate":7.22,"mode":"test","object":"Rate","rate":7.22,"retail_currency":"USD","retail_rate":7.22,"service":"ParcelSelect","shipment_id":"shp_f1995fdbb0ed41d0ad3152436148bce9","time_in_transit":{"percentile_50":1,"percentile_75":2,"percentile_85":3,"percentile_90":4,"percentile_95":4,"percentile_97":5,"percentile_99":7},"updated_at":"2022-04-29T20:13:54Z"},{"carrier":"USPS","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b","created_at":"2022-04-29T20:13:54Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":2,"est_delivery_days":2,"id":"rate_b84f8100c8f042a2878384afc3e8241e","list_currency":"USD","list_rate":5.49,"mode":"test","object":"Rate","rate":5.49,"retail_currency":"USD","retail_rate":5.49,"service":"First","shipment_id":"shp_f1995fdbb0ed41d0ad3152436148bce9","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":2,"percentile_95":2,"percentile_97":2,"percentile_99":3},"updated_at":"2022-04-29T20:13:54Z"},{"carrier":"USPS","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b","created_at":"2022-04-29T20:13:54Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":null,"est_delivery_days":null,"id":"rate_77def4f15869406db566c7317ad6036b","list_currency":"USD","list_rate":23.75,"mode":"test","object":"Rate","rate":23.75,"retail_currency":"USD","retail_rate":27.4,"service":"Express","shipment_id":"shp_f1995fdbb0ed41d0ad3152436148bce9","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":1,"percentile_95":2,"percentile_97":2,"percentile_99":4},"updated_at":"2022-04-29T20:13:54Z"},{"carrier":"USPS","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b","created_at":"2022-04-29T20:13:54Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":1,"est_delivery_days":1,"id":"rate_b20e2f0b65ba4803be40817f3422b1e9","list_currency":"USD","list_rate":7.37,"mode":"test","object":"Rate","rate":7.37,"retail_currency":"USD","retail_rate":8.7,"service":"Priority","shipment_id":"shp_f1995fdbb0ed41d0ad3152436148bce9","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":1,"percentile_95":2,"percentile_97":2,"percentile_99":4},"updated_at":"2022-04-29T20:13:54Z"}]}'
+  recorded_at: Fri, 29 Apr 2022 20:13:54 GMT
+recorded_with: VCR 6.0.0

--- a/spec/cassettes/shipment/EasyPost_Shipment_get_lowest_smartrate_raises_an_error_when_no_rates_are_found_due_to_delivery_days.yml
+++ b/spec/cassettes/shipment/EasyPost_Shipment_get_lowest_smartrate_raises_an_error_when_no_rates_are_found_due_to_delivery_days.yml
@@ -1,0 +1,144 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.easypost.com/v2/shipments
+    body:
+      encoding: UTF-8
+      string: '{"shipment":{"to_address":{"name":"Jack Sparrow","company":"EasyPost","street1":"388
+        Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","phone":"5555555555"},"from_address":{"name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","phone":"5555555555"},"parcel":{"length":"10","width":"8","height":"4","weight":"15.4"}}}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - EasyPost/v2 RubyClient/4.1.2 Ruby/3.1.1-p18
+      Content-Type:
+      - application/json
+      Authorization: "<AUTHORIZATION>"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      X-Ep-Request-Uuid:
+      - b1df9425626c4701e7874040005033c5
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Location:
+      - "/api/v2/shipments/shp_39195bcc20dd47ee8c782b155447d0ac"
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"2f84ad02d24a3d42d12e9380b51fd643"
+      X-Runtime:
+      - '0.188258'
+      Transfer-Encoding:
+      - chunked
+      X-Node:
+      - bigweb8nuq
+      X-Version-Label:
+      - easypost-202204282028-6188e715cb-master
+      X-Backend:
+      - easypost
+      X-Proxied:
+      - extlb2nuq 5fac7c1107
+      - intlb1nuq fde591f008
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: '{"created_at":"2022-04-29T20:13:53Z","is_return":false,"messages":[],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":null,"updated_at":"2022-04-29T20:13:53Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_e3fd26bfc7f811ecb6cbac1f6bc7b362","object":"Address","created_at":"2022-04-29T20:13:53+00:00","updated_at":"2022-04-29T20:13:53+00:00","name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_34ebafa4fb83495a9adb5aa282c59d83","object":"Parcel","created_at":"2022-04-29T20:13:53Z","updated_at":"2022-04-29T20:13:53Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":null,"rates":[{"id":"rate_058448b423b54d42885b8f5e96e820a5","object":"Rate","created_at":"2022-04-29T20:13:53Z","updated_at":"2022-04-29T20:13:53Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_39195bcc20dd47ee8c782b155447d0ac","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},{"id":"rate_9aa74a6064dc4fafb534741ead9513fd","object":"Rate","created_at":"2022-04-29T20:13:53Z","updated_at":"2022-04-29T20:13:53Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_39195bcc20dd47ee8c782b155447d0ac","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},{"id":"rate_54c24987c9bc4d8dab428790d92b7eee","object":"Rate","created_at":"2022-04-29T20:13:53Z","updated_at":"2022-04-29T20:13:53Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_39195bcc20dd47ee8c782b155447d0ac","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},{"id":"rate_ea75d96931db41bba2e7a19d472d5261","object":"Rate","created_at":"2022-04-29T20:13:53Z","updated_at":"2022-04-29T20:13:53Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_39195bcc20dd47ee8c782b155447d0ac","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"}],"refund_status":null,"scan_form":null,"selected_rate":null,"tracker":null,"to_address":{"id":"adr_e3fb797cc7f811ecb6c9ac1f6bc7b362","object":"Address","created_at":"2022-04-29T20:13:53+00:00","updated_at":"2022-04-29T20:13:53+00:00","name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"usps_zone":1,"return_address":{"id":"adr_e3fd26bfc7f811ecb6cbac1f6bc7b362","object":"Address","created_at":"2022-04-29T20:13:53+00:00","updated_at":"2022-04-29T20:13:53+00:00","name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_e3fb797cc7f811ecb6c9ac1f6bc7b362","object":"Address","created_at":"2022-04-29T20:13:53+00:00","updated_at":"2022-04-29T20:13:53+00:00","name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"forms":[],"fees":[],"id":"shp_39195bcc20dd47ee8c782b155447d0ac","object":"Shipment"}'
+  recorded_at: Fri, 29 Apr 2022 20:13:53 GMT
+- request:
+    method: get
+    uri: https://api.easypost.com/v2/shipments/shp_39195bcc20dd47ee8c782b155447d0ac/smartrate
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - EasyPost/v2 RubyClient/4.1.2 Ruby/3.1.1-p18
+      Content-Type:
+      - application/json
+      Authorization: "<AUTHORIZATION>"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      X-Ep-Request-Uuid:
+      - b1df9425626c4701e7874041005033ef
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"e9a0ac78688f554d0a2d7b242ffe3869"
+      X-Runtime:
+      - '0.076813'
+      Transfer-Encoding:
+      - chunked
+      X-Node:
+      - bigweb2nuq
+      X-Version-Label:
+      - easypost-202204282028-6188e715cb-master
+      X-Backend:
+      - easypost
+      X-Proxied:
+      - extlb2nuq 5fac7c1107
+      - intlb2nuq fde591f008
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: '{"result":[{"carrier":"USPS","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b","created_at":"2022-04-29T20:13:53Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":null,"est_delivery_days":null,"id":"rate_058448b423b54d42885b8f5e96e820a5","list_currency":"USD","list_rate":23.75,"mode":"test","object":"Rate","rate":23.75,"retail_currency":"USD","retail_rate":27.4,"service":"Express","shipment_id":"shp_39195bcc20dd47ee8c782b155447d0ac","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":1,"percentile_95":2,"percentile_97":2,"percentile_99":4},"updated_at":"2022-04-29T20:13:53Z"},{"carrier":"USPS","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b","created_at":"2022-04-29T20:13:53Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":1,"est_delivery_days":1,"id":"rate_9aa74a6064dc4fafb534741ead9513fd","list_currency":"USD","list_rate":7.37,"mode":"test","object":"Rate","rate":7.37,"retail_currency":"USD","retail_rate":8.7,"service":"Priority","shipment_id":"shp_39195bcc20dd47ee8c782b155447d0ac","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":1,"percentile_95":2,"percentile_97":2,"percentile_99":4},"updated_at":"2022-04-29T20:13:53Z"},{"carrier":"USPS","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b","created_at":"2022-04-29T20:13:53Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":2,"est_delivery_days":2,"id":"rate_54c24987c9bc4d8dab428790d92b7eee","list_currency":"USD","list_rate":7.22,"mode":"test","object":"Rate","rate":7.22,"retail_currency":"USD","retail_rate":7.22,"service":"ParcelSelect","shipment_id":"shp_39195bcc20dd47ee8c782b155447d0ac","time_in_transit":{"percentile_50":1,"percentile_75":2,"percentile_85":3,"percentile_90":4,"percentile_95":4,"percentile_97":5,"percentile_99":7},"updated_at":"2022-04-29T20:13:53Z"},{"carrier":"USPS","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b","created_at":"2022-04-29T20:13:53Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":2,"est_delivery_days":2,"id":"rate_ea75d96931db41bba2e7a19d472d5261","list_currency":"USD","list_rate":5.49,"mode":"test","object":"Rate","rate":5.49,"retail_currency":"USD","retail_rate":5.49,"service":"First","shipment_id":"shp_39195bcc20dd47ee8c782b155447d0ac","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":2,"percentile_95":2,"percentile_97":2,"percentile_99":3},"updated_at":"2022-04-29T20:13:53Z"}]}'
+  recorded_at: Fri, 29 Apr 2022 20:13:53 GMT
+recorded_with: VCR 6.0.0

--- a/spec/cassettes/shipment/EasyPost_Shipment_lowest_rate_tests_various_usage_alterations_of_the_lowest_rate_method.yml
+++ b/spec/cassettes/shipment/EasyPost_Shipment_lowest_rate_tests_various_usage_alterations_of_the_lowest_rate_method.yml
@@ -1,0 +1,84 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.easypost.com/v2/shipments
+    body:
+      encoding: UTF-8
+      string: '{"shipment":{"to_address":{"name":"Jack Sparrow","company":"EasyPost","street1":"388
+        Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","phone":"5555555555"},"from_address":{"name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","phone":"5555555555"},"parcel":{"length":"10","width":"8","height":"4","weight":"15.4"},"customs_info":{"eel_pfc":"NOEEI
+        30.37(a)","customs_certify":true,"customs_signer":"Steve Brule","contents_type":"merchandise","contents_explanation":"","restriction_type":"none","non_delivery_option":"return","customs_items":[{"description":"Sweet
+        shirts","quantity":2,"weight":11,"value":23,"hs_tariff_number":"654321","origin_country":"US"}]},"options":{"label_format":"PNG","invoice_number":"123"},"reference":"123"}}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - EasyPost/v2 RubyClient/4.1.2 Ruby/3.1.1-p18
+      Content-Type:
+      - application/json
+      Authorization: "<AUTHORIZATION>"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      X-Ep-Request-Uuid:
+      - b1df9427626c46fde787402000503235
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Location:
+      - "/api/v2/shipments/shp_4ed623c1e39143c2ad9667bf894c1322"
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"8874f3c37a0c2d35ad486e9f26e1635a"
+      X-Runtime:
+      - '0.216649'
+      Transfer-Encoding:
+      - chunked
+      X-Node:
+      - bigweb4nuq
+      X-Version-Label:
+      - easypost-202204282028-6188e715cb-master
+      X-Backend:
+      - easypost
+      X-Proxied:
+      - extlb2nuq 5fac7c1107
+      - intlb2nuq fde591f008
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: '{"created_at":"2022-04-29T20:13:49Z","is_return":false,"messages":[],"mode":"test","options":{"label_format":"PNG","invoice_number":"123","currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":"123","status":"unknown","tracking_code":null,"updated_at":"2022-04-29T20:13:49Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":{"id":"cstinfo_b51e1bf8e8af438cb798382eb7026836","object":"CustomsInfo","created_at":"2022-04-29T20:13:49Z","updated_at":"2022-04-29T20:13:49Z","contents_explanation":"","contents_type":"merchandise","customs_certify":true,"customs_signer":"Steve
+        Brule","eel_pfc":"NOEEI 30.37(a)","non_delivery_option":"return","restriction_comments":null,"restriction_type":"none","mode":"test","declaration":null,"customs_items":[{"id":"cstitem_8d9d760725b9447585af8e73e1a52046","object":"CustomsItem","created_at":"2022-04-29T20:13:49Z","updated_at":"2022-04-29T20:13:49Z","description":"Sweet
+        shirts","hs_tariff_number":"654321","origin_country":"US","quantity":2,"value":"23.0","weight":11.0,"code":null,"mode":"test","manufacturer":null,"currency":null,"eccn":null,"printed_commodity_identifier":null}]},"from_address":{"id":"adr_e1fcf018c7f811ec9137ac1f6b0a0d1e","object":"Address","created_at":"2022-04-29T20:13:49+00:00","updated_at":"2022-04-29T20:13:49+00:00","name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_b58f7013e11847e9b7a7f9eb30d61baa","object":"Parcel","created_at":"2022-04-29T20:13:49Z","updated_at":"2022-04-29T20:13:49Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":null,"rates":[{"id":"rate_c5f4e40985464d6eb9590a85066bc6b6","object":"Rate","created_at":"2022-04-29T20:13:50Z","updated_at":"2022-04-29T20:13:50Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_4ed623c1e39143c2ad9667bf894c1322","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},{"id":"rate_eec950855c1f4e0f9b736893fed489ca","object":"Rate","created_at":"2022-04-29T20:13:50Z","updated_at":"2022-04-29T20:13:50Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_4ed623c1e39143c2ad9667bf894c1322","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},{"id":"rate_c5b0782336ee4c548f5b2622bb1f1cf7","object":"Rate","created_at":"2022-04-29T20:13:50Z","updated_at":"2022-04-29T20:13:50Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_4ed623c1e39143c2ad9667bf894c1322","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},{"id":"rate_4853988ac6eb4082b74a412433b108cd","object":"Rate","created_at":"2022-04-29T20:13:50Z","updated_at":"2022-04-29T20:13:50Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_4ed623c1e39143c2ad9667bf894c1322","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"}],"refund_status":null,"scan_form":null,"selected_rate":null,"tracker":null,"to_address":{"id":"adr_e1fb0244c7f811ecb2d1ac1f6bc7bdc6","object":"Address","created_at":"2022-04-29T20:13:49+00:00","updated_at":"2022-04-29T20:13:49+00:00","name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"usps_zone":1,"return_address":{"id":"adr_e1fcf018c7f811ec9137ac1f6b0a0d1e","object":"Address","created_at":"2022-04-29T20:13:49+00:00","updated_at":"2022-04-29T20:13:49+00:00","name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_e1fb0244c7f811ecb2d1ac1f6bc7bdc6","object":"Address","created_at":"2022-04-29T20:13:49+00:00","updated_at":"2022-04-29T20:13:49+00:00","name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"forms":[],"fees":[],"id":"shp_4ed623c1e39143c2ad9667bf894c1322","object":"Shipment"}'
+  recorded_at: Fri, 29 Apr 2022 20:13:50 GMT
+recorded_with: VCR 6.0.0

--- a/spec/cassettes/shipment/EasyPost_Shipment_lowest_smartrate_gets_the_lowest_smartrate_of_a_shipment.yml
+++ b/spec/cassettes/shipment/EasyPost_Shipment_lowest_smartrate_gets_the_lowest_smartrate_of_a_shipment.yml
@@ -1,0 +1,144 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.easypost.com/v2/shipments
+    body:
+      encoding: UTF-8
+      string: '{"shipment":{"to_address":{"name":"Jack Sparrow","company":"EasyPost","street1":"388
+        Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","phone":"5555555555"},"from_address":{"name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","phone":"5555555555"},"parcel":{"length":"10","width":"8","height":"4","weight":"15.4"}}}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - EasyPost/v2 RubyClient/4.1.2 Ruby/3.1.1-p18
+      Content-Type:
+      - application/json
+      Authorization: "<AUTHORIZATION>"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      X-Ep-Request-Uuid:
+      - b1df9427626c46fee78740210050326e
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Location:
+      - "/api/v2/shipments/shp_1b7a54f8cbd540c28691b7da8cbb2a8b"
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"1cb5e3880dbd919c2da9954829575e4b"
+      X-Runtime:
+      - '0.199407'
+      Transfer-Encoding:
+      - chunked
+      X-Node:
+      - bigweb1nuq
+      X-Version-Label:
+      - easypost-202204282028-6188e715cb-master
+      X-Backend:
+      - easypost
+      X-Proxied:
+      - extlb2nuq 5fac7c1107
+      - intlb1nuq fde591f008
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: '{"created_at":"2022-04-29T20:13:50Z","is_return":false,"messages":[],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":null,"updated_at":"2022-04-29T20:13:50Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_e23c10a2c7f811ecb634ac1f6bc7b362","object":"Address","created_at":"2022-04-29T20:13:50+00:00","updated_at":"2022-04-29T20:13:50+00:00","name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_bd2fba04c9c7485fa495bb9618e1a2ac","object":"Parcel","created_at":"2022-04-29T20:13:50Z","updated_at":"2022-04-29T20:13:50Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":null,"rates":[{"id":"rate_f43dab2434d546ce80aad2b7004aa7f3","object":"Rate","created_at":"2022-04-29T20:13:50Z","updated_at":"2022-04-29T20:13:50Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_1b7a54f8cbd540c28691b7da8cbb2a8b","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},{"id":"rate_80ed0d12da84408bb9d12b3242f6a985","object":"Rate","created_at":"2022-04-29T20:13:50Z","updated_at":"2022-04-29T20:13:50Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_1b7a54f8cbd540c28691b7da8cbb2a8b","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},{"id":"rate_eb071429e4a74cc6a2a3290bfab06727","object":"Rate","created_at":"2022-04-29T20:13:50Z","updated_at":"2022-04-29T20:13:50Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_1b7a54f8cbd540c28691b7da8cbb2a8b","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},{"id":"rate_54d2f586f9d9403286646999120210b2","object":"Rate","created_at":"2022-04-29T20:13:50Z","updated_at":"2022-04-29T20:13:50Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_1b7a54f8cbd540c28691b7da8cbb2a8b","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"}],"refund_status":null,"scan_form":null,"selected_rate":null,"tracker":null,"to_address":{"id":"adr_e23a28cdc7f811ecb2e3ac1f6bc7bdc6","object":"Address","created_at":"2022-04-29T20:13:50+00:00","updated_at":"2022-04-29T20:13:50+00:00","name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"usps_zone":1,"return_address":{"id":"adr_e23c10a2c7f811ecb634ac1f6bc7b362","object":"Address","created_at":"2022-04-29T20:13:50+00:00","updated_at":"2022-04-29T20:13:50+00:00","name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_e23a28cdc7f811ecb2e3ac1f6bc7bdc6","object":"Address","created_at":"2022-04-29T20:13:50+00:00","updated_at":"2022-04-29T20:13:50+00:00","name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"forms":[],"fees":[],"id":"shp_1b7a54f8cbd540c28691b7da8cbb2a8b","object":"Shipment"}'
+  recorded_at: Fri, 29 Apr 2022 20:13:50 GMT
+- request:
+    method: get
+    uri: https://api.easypost.com/v2/shipments/shp_1b7a54f8cbd540c28691b7da8cbb2a8b/smartrate
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - EasyPost/v2 RubyClient/4.1.2 Ruby/3.1.1-p18
+      Content-Type:
+      - application/json
+      Authorization: "<AUTHORIZATION>"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      X-Ep-Request-Uuid:
+      - b1df942a626c46fee7874039005032a1
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"a07aeae47d775f357ec6c0fa3255bf08"
+      X-Runtime:
+      - '0.068939'
+      Transfer-Encoding:
+      - chunked
+      X-Node:
+      - bigweb3nuq
+      X-Version-Label:
+      - easypost-202204282028-6188e715cb-master
+      X-Backend:
+      - easypost
+      X-Proxied:
+      - extlb2nuq 5fac7c1107
+      - intlb1nuq fde591f008
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: '{"result":[{"carrier":"USPS","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b","created_at":"2022-04-29T20:13:50Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":1,"est_delivery_days":1,"id":"rate_f43dab2434d546ce80aad2b7004aa7f3","list_currency":"USD","list_rate":7.37,"mode":"test","object":"Rate","rate":7.37,"retail_currency":"USD","retail_rate":8.7,"service":"Priority","shipment_id":"shp_1b7a54f8cbd540c28691b7da8cbb2a8b","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":1,"percentile_95":2,"percentile_97":2,"percentile_99":4},"updated_at":"2022-04-29T20:13:50Z"},{"carrier":"USPS","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b","created_at":"2022-04-29T20:13:50Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":null,"est_delivery_days":null,"id":"rate_80ed0d12da84408bb9d12b3242f6a985","list_currency":"USD","list_rate":23.75,"mode":"test","object":"Rate","rate":23.75,"retail_currency":"USD","retail_rate":27.4,"service":"Express","shipment_id":"shp_1b7a54f8cbd540c28691b7da8cbb2a8b","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":1,"percentile_95":2,"percentile_97":2,"percentile_99":4},"updated_at":"2022-04-29T20:13:50Z"},{"carrier":"USPS","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b","created_at":"2022-04-29T20:13:50Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":2,"est_delivery_days":2,"id":"rate_eb071429e4a74cc6a2a3290bfab06727","list_currency":"USD","list_rate":7.22,"mode":"test","object":"Rate","rate":7.22,"retail_currency":"USD","retail_rate":7.22,"service":"ParcelSelect","shipment_id":"shp_1b7a54f8cbd540c28691b7da8cbb2a8b","time_in_transit":{"percentile_50":1,"percentile_75":2,"percentile_85":3,"percentile_90":4,"percentile_95":4,"percentile_97":5,"percentile_99":7},"updated_at":"2022-04-29T20:13:50Z"},{"carrier":"USPS","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b","created_at":"2022-04-29T20:13:50Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":2,"est_delivery_days":2,"id":"rate_54d2f586f9d9403286646999120210b2","list_currency":"USD","list_rate":5.49,"mode":"test","object":"Rate","rate":5.49,"retail_currency":"USD","retail_rate":5.49,"service":"First","shipment_id":"shp_1b7a54f8cbd540c28691b7da8cbb2a8b","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":2,"percentile_95":2,"percentile_97":2,"percentile_99":3},"updated_at":"2022-04-29T20:13:50Z"}]}'
+  recorded_at: Fri, 29 Apr 2022 20:13:50 GMT
+recorded_with: VCR 6.0.0

--- a/spec/cassettes/shipment/EasyPost_Shipment_lowest_smartrate_raises_an_error_when_no_rates_are_found_due_to_delivery_accuracy.yml
+++ b/spec/cassettes/shipment/EasyPost_Shipment_lowest_smartrate_raises_an_error_when_no_rates_are_found_due_to_delivery_accuracy.yml
@@ -1,0 +1,144 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.easypost.com/v2/shipments
+    body:
+      encoding: UTF-8
+      string: '{"shipment":{"to_address":{"name":"Jack Sparrow","company":"EasyPost","street1":"388
+        Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","phone":"5555555555"},"from_address":{"name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","phone":"5555555555"},"parcel":{"length":"10","width":"8","height":"4","weight":"15.4"}}}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - EasyPost/v2 RubyClient/4.1.2 Ruby/3.1.1-p18
+      Content-Type:
+      - application/json
+      Authorization: "<AUTHORIZATION>"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      X-Ep-Request-Uuid:
+      - b1df9429626c46ffe787403c00503316
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Location:
+      - "/api/v2/shipments/shp_837f78e159974fefb6e46fd4c2415a9e"
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"5d73bbe3ec1ae046e14926f25263aac5"
+      X-Runtime:
+      - '0.191170'
+      Transfer-Encoding:
+      - chunked
+      X-Node:
+      - bigweb4nuq
+      X-Version-Label:
+      - easypost-202204282028-6188e715cb-master
+      X-Backend:
+      - easypost
+      X-Proxied:
+      - extlb2nuq 5fac7c1107
+      - intlb1nuq fde591f008
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: '{"created_at":"2022-04-29T20:13:51Z","is_return":false,"messages":[],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":null,"updated_at":"2022-04-29T20:13:51Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_e31f23d7c7f811ec9e20ac1f6bc72124","object":"Address","created_at":"2022-04-29T20:13:51+00:00","updated_at":"2022-04-29T20:13:51+00:00","name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_3375ebd34d1445dfb81192075dc956b1","object":"Parcel","created_at":"2022-04-29T20:13:51Z","updated_at":"2022-04-29T20:13:51Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":null,"rates":[{"id":"rate_e560cc7ede2f4cf58c7d78433234e309","object":"Rate","created_at":"2022-04-29T20:13:51Z","updated_at":"2022-04-29T20:13:51Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_837f78e159974fefb6e46fd4c2415a9e","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},{"id":"rate_4c44ab33924b47c49f7aebe94fd8adb6","object":"Rate","created_at":"2022-04-29T20:13:51Z","updated_at":"2022-04-29T20:13:51Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_837f78e159974fefb6e46fd4c2415a9e","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},{"id":"rate_653a80f994ef420ab700a1da5d87d008","object":"Rate","created_at":"2022-04-29T20:13:51Z","updated_at":"2022-04-29T20:13:51Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_837f78e159974fefb6e46fd4c2415a9e","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},{"id":"rate_e53cb8bd825c4a3a9cbc7d6730a11f7d","object":"Rate","created_at":"2022-04-29T20:13:51Z","updated_at":"2022-04-29T20:13:51Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_837f78e159974fefb6e46fd4c2415a9e","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"}],"refund_status":null,"scan_form":null,"selected_rate":null,"tracker":null,"to_address":{"id":"adr_e31d5bdac7f811ecb684ac1f6bc7b362","object":"Address","created_at":"2022-04-29T20:13:51+00:00","updated_at":"2022-04-29T20:13:51+00:00","name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"usps_zone":1,"return_address":{"id":"adr_e31f23d7c7f811ec9e20ac1f6bc72124","object":"Address","created_at":"2022-04-29T20:13:51+00:00","updated_at":"2022-04-29T20:13:51+00:00","name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_e31d5bdac7f811ecb684ac1f6bc7b362","object":"Address","created_at":"2022-04-29T20:13:51+00:00","updated_at":"2022-04-29T20:13:51+00:00","name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"forms":[],"fees":[],"id":"shp_837f78e159974fefb6e46fd4c2415a9e","object":"Shipment"}'
+  recorded_at: Fri, 29 Apr 2022 20:13:51 GMT
+- request:
+    method: get
+    uri: https://api.easypost.com/v2/shipments/shp_837f78e159974fefb6e46fd4c2415a9e/smartrate
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - EasyPost/v2 RubyClient/4.1.2 Ruby/3.1.1-p18
+      Content-Type:
+      - application/json
+      Authorization: "<AUTHORIZATION>"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      X-Ep-Request-Uuid:
+      - b1df942a626c4700e787403d0050333c
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"d8aa65ceb6b548a5f45583917343577b"
+      X-Runtime:
+      - '0.076550'
+      Transfer-Encoding:
+      - chunked
+      X-Node:
+      - bigweb8nuq
+      X-Version-Label:
+      - easypost-202204282028-6188e715cb-master
+      X-Backend:
+      - easypost
+      X-Proxied:
+      - extlb2nuq 5fac7c1107
+      - intlb1nuq fde591f008
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: '{"result":[{"carrier":"USPS","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b","created_at":"2022-04-29T20:13:51Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":null,"est_delivery_days":null,"id":"rate_e560cc7ede2f4cf58c7d78433234e309","list_currency":"USD","list_rate":23.75,"mode":"test","object":"Rate","rate":23.75,"retail_currency":"USD","retail_rate":27.4,"service":"Express","shipment_id":"shp_837f78e159974fefb6e46fd4c2415a9e","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":1,"percentile_95":2,"percentile_97":2,"percentile_99":4},"updated_at":"2022-04-29T20:13:51Z"},{"carrier":"USPS","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b","created_at":"2022-04-29T20:13:51Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":1,"est_delivery_days":1,"id":"rate_4c44ab33924b47c49f7aebe94fd8adb6","list_currency":"USD","list_rate":7.37,"mode":"test","object":"Rate","rate":7.37,"retail_currency":"USD","retail_rate":8.7,"service":"Priority","shipment_id":"shp_837f78e159974fefb6e46fd4c2415a9e","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":1,"percentile_95":2,"percentile_97":2,"percentile_99":4},"updated_at":"2022-04-29T20:13:51Z"},{"carrier":"USPS","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b","created_at":"2022-04-29T20:13:51Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":2,"est_delivery_days":2,"id":"rate_653a80f994ef420ab700a1da5d87d008","list_currency":"USD","list_rate":7.22,"mode":"test","object":"Rate","rate":7.22,"retail_currency":"USD","retail_rate":7.22,"service":"ParcelSelect","shipment_id":"shp_837f78e159974fefb6e46fd4c2415a9e","time_in_transit":{"percentile_50":1,"percentile_75":2,"percentile_85":3,"percentile_90":4,"percentile_95":4,"percentile_97":5,"percentile_99":7},"updated_at":"2022-04-29T20:13:51Z"},{"carrier":"USPS","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b","created_at":"2022-04-29T20:13:51Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":2,"est_delivery_days":2,"id":"rate_e53cb8bd825c4a3a9cbc7d6730a11f7d","list_currency":"USD","list_rate":5.49,"mode":"test","object":"Rate","rate":5.49,"retail_currency":"USD","retail_rate":5.49,"service":"First","shipment_id":"shp_837f78e159974fefb6e46fd4c2415a9e","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":2,"percentile_95":2,"percentile_97":2,"percentile_99":3},"updated_at":"2022-04-29T20:13:51Z"}]}'
+  recorded_at: Fri, 29 Apr 2022 20:13:52 GMT
+recorded_with: VCR 6.0.0

--- a/spec/cassettes/shipment/EasyPost_Shipment_lowest_smartrate_raises_an_error_when_no_rates_are_found_due_to_delivery_days.yml
+++ b/spec/cassettes/shipment/EasyPost_Shipment_lowest_smartrate_raises_an_error_when_no_rates_are_found_due_to_delivery_days.yml
@@ -1,0 +1,144 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.easypost.com/v2/shipments
+    body:
+      encoding: UTF-8
+      string: '{"shipment":{"to_address":{"name":"Jack Sparrow","company":"EasyPost","street1":"388
+        Townsend St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","phone":"5555555555"},"from_address":{"name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","phone":"5555555555"},"parcel":{"length":"10","width":"8","height":"4","weight":"15.4"}}}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - EasyPost/v2 RubyClient/4.1.2 Ruby/3.1.1-p18
+      Content-Type:
+      - application/json
+      Authorization: "<AUTHORIZATION>"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      X-Ep-Request-Uuid:
+      - b1df9428626c46fee787403a005032b8
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Location:
+      - "/api/v2/shipments/shp_2bc918db146145aaa86c73bc9b3bab65"
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"b4e0d7e526ce050c30b98362bad8a192"
+      X-Runtime:
+      - '0.224431'
+      Transfer-Encoding:
+      - chunked
+      X-Node:
+      - bigweb3nuq
+      X-Version-Label:
+      - easypost-202204282028-6188e715cb-master
+      X-Backend:
+      - easypost
+      X-Proxied:
+      - extlb2nuq 5fac7c1107
+      - intlb2nuq fde591f008
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: '{"created_at":"2022-04-29T20:13:50Z","is_return":false,"messages":[],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":null,"updated_at":"2022-04-29T20:13:50Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_e2a1a7fdc7f811ecb2f8ac1f6bc7bdc6","object":"Address","created_at":"2022-04-29T20:13:50+00:00","updated_at":"2022-04-29T20:13:50+00:00","name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_81aee0f94f79497bbb2f0385258dcdc0","object":"Parcel","created_at":"2022-04-29T20:13:50Z","updated_at":"2022-04-29T20:13:50Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":null,"rates":[{"id":"rate_71ec965b680e47c2bcd5cd18a8de4aa3","object":"Rate","created_at":"2022-04-29T20:13:51Z","updated_at":"2022-04-29T20:13:51Z","mode":"test","service":"First","carrier":"USPS","rate":"5.49","currency":"USD","retail_rate":"5.49","retail_currency":"USD","list_rate":"5.49","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_2bc918db146145aaa86c73bc9b3bab65","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},{"id":"rate_67d9c47911694e67b9cd1ff3186ab4d4","object":"Rate","created_at":"2022-04-29T20:13:51Z","updated_at":"2022-04-29T20:13:51Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.22","currency":"USD","retail_rate":"7.22","retail_currency":"USD","list_rate":"7.22","list_currency":"USD","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_2bc918db146145aaa86c73bc9b3bab65","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},{"id":"rate_728c1071312d4aa486806bceabb8ce3b","object":"Rate","created_at":"2022-04-29T20:13:51Z","updated_at":"2022-04-29T20:13:51Z","mode":"test","service":"Express","carrier":"USPS","rate":"23.75","currency":"USD","retail_rate":"27.40","retail_currency":"USD","list_rate":"23.75","list_currency":"USD","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_2bc918db146145aaa86c73bc9b3bab65","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},{"id":"rate_8804b0bb73124761974d99bc8ddc6dc4","object":"Rate","created_at":"2022-04-29T20:13:51Z","updated_at":"2022-04-29T20:13:51Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.37","currency":"USD","retail_rate":"8.70","retail_currency":"USD","list_rate":"7.37","list_currency":"USD","delivery_days":1,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":1,"shipment_id":"shp_2bc918db146145aaa86c73bc9b3bab65","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"}],"refund_status":null,"scan_form":null,"selected_rate":null,"tracker":null,"to_address":{"id":"adr_e29fae70c7f811ecb660ac1f6bc7b362","object":"Address","created_at":"2022-04-29T20:13:50+00:00","updated_at":"2022-04-29T20:13:50+00:00","name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"usps_zone":1,"return_address":{"id":"adr_e2a1a7fdc7f811ecb2f8ac1f6bc7bdc6","object":"Address","created_at":"2022-04-29T20:13:50+00:00","updated_at":"2022-04-29T20:13:50+00:00","name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_e29fae70c7f811ecb660ac1f6bc7b362","object":"Address","created_at":"2022-04-29T20:13:50+00:00","updated_at":"2022-04-29T20:13:50+00:00","name":"Jack
+        Sparrow","company":"EasyPost","street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":null,"mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"forms":[],"fees":[],"id":"shp_2bc918db146145aaa86c73bc9b3bab65","object":"Shipment"}'
+  recorded_at: Fri, 29 Apr 2022 20:13:51 GMT
+- request:
+    method: get
+    uri: https://api.easypost.com/v2/shipments/shp_2bc918db146145aaa86c73bc9b3bab65/smartrate
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - EasyPost/v2 RubyClient/4.1.2 Ruby/3.1.1-p18
+      Content-Type:
+      - application/json
+      Authorization: "<AUTHORIZATION>"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      X-Ep-Request-Uuid:
+      - b1df942c626c46ffe787403b005032e6
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"9878eeb287e82da0fb70d93921da7a25"
+      X-Runtime:
+      - '0.079163'
+      Transfer-Encoding:
+      - chunked
+      X-Node:
+      - bigweb3nuq
+      X-Version-Label:
+      - easypost-202204282028-6188e715cb-master
+      X-Backend:
+      - easypost
+      X-Proxied:
+      - extlb2nuq 5fac7c1107
+      - intlb2nuq fde591f008
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+    body:
+      encoding: ASCII-8BIT
+      string: '{"result":[{"carrier":"USPS","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b","created_at":"2022-04-29T20:13:51Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":2,"est_delivery_days":2,"id":"rate_71ec965b680e47c2bcd5cd18a8de4aa3","list_currency":"USD","list_rate":5.49,"mode":"test","object":"Rate","rate":5.49,"retail_currency":"USD","retail_rate":5.49,"service":"First","shipment_id":"shp_2bc918db146145aaa86c73bc9b3bab65","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":2,"percentile_95":2,"percentile_97":2,"percentile_99":3},"updated_at":"2022-04-29T20:13:51Z"},{"carrier":"USPS","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b","created_at":"2022-04-29T20:13:51Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":2,"est_delivery_days":2,"id":"rate_67d9c47911694e67b9cd1ff3186ab4d4","list_currency":"USD","list_rate":7.22,"mode":"test","object":"Rate","rate":7.22,"retail_currency":"USD","retail_rate":7.22,"service":"ParcelSelect","shipment_id":"shp_2bc918db146145aaa86c73bc9b3bab65","time_in_transit":{"percentile_50":1,"percentile_75":2,"percentile_85":3,"percentile_90":4,"percentile_95":4,"percentile_97":5,"percentile_99":7},"updated_at":"2022-04-29T20:13:51Z"},{"carrier":"USPS","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b","created_at":"2022-04-29T20:13:51Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":null,"est_delivery_days":null,"id":"rate_728c1071312d4aa486806bceabb8ce3b","list_currency":"USD","list_rate":23.75,"mode":"test","object":"Rate","rate":23.75,"retail_currency":"USD","retail_rate":27.4,"service":"Express","shipment_id":"shp_2bc918db146145aaa86c73bc9b3bab65","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":1,"percentile_95":2,"percentile_97":2,"percentile_99":4},"updated_at":"2022-04-29T20:13:51Z"},{"carrier":"USPS","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b","created_at":"2022-04-29T20:13:51Z","currency":"USD","delivery_date":null,"delivery_date_guaranteed":false,"delivery_days":1,"est_delivery_days":1,"id":"rate_8804b0bb73124761974d99bc8ddc6dc4","list_currency":"USD","list_rate":7.37,"mode":"test","object":"Rate","rate":7.37,"retail_currency":"USD","retail_rate":8.7,"service":"Priority","shipment_id":"shp_2bc918db146145aaa86c73bc9b3bab65","time_in_transit":{"percentile_50":1,"percentile_75":1,"percentile_85":1,"percentile_90":1,"percentile_95":2,"percentile_97":2,"percentile_99":4},"updated_at":"2022-04-29T20:13:51Z"}]}'
+  recorded_at: Fri, 29 Apr 2022 20:13:51 GMT
+recorded_with: VCR 6.0.0

--- a/spec/order_spec.rb
+++ b/spec/order_spec.rb
@@ -57,4 +57,27 @@ describe EasyPost::Order do
       end
     end
   end
+
+  describe '.lowest_rate' do
+    it 'tests various usage alterations of the lowest_rate method' do
+      shipment = described_class.create(Fixture.basic_order)
+
+      # Test lowest rate with no filters
+      lowest_rate = shipment.lowest_rate
+      expect(lowest_rate.service).to eq('First')
+      expect(lowest_rate.rate).to eq('5.49')
+      expect(lowest_rate.carrier).to eq('USPS')
+
+      # Test lowest rate with service filter (this rate is higher than the lowest but should filter)
+      lowest_rate = shipment.lowest_rate([], ['Priority'])
+      expect(lowest_rate.service).to eq('Priority')
+      expect(lowest_rate.rate).to eq('7.37')
+      expect(lowest_rate.carrier).to eq('USPS')
+
+      # Test lowest rate with carrier filter (should error due to bad carrier)
+      expect {
+        shipment.lowest_rate(['BAD CARRIER'], [])
+      }.to raise_error(EasyPost::Error, 'No rates found.')
+    end
+  end
 end

--- a/spec/pickup_spec.rb
+++ b/spec/pickup_spec.rb
@@ -81,4 +81,31 @@ describe EasyPost::Pickup do
       expect(cancelled_pickup.status).to eq('canceled')
     end
   end
+
+  describe '.lowest_rate' do
+    it 'tests various usage alterations of the lowest_rate method' do
+      shipment = EasyPost::Shipment.create(Fixture.one_call_buy_shipment)
+
+      pickup_data = Fixture.basic_pickup
+      pickup_data[:shipment] = shipment
+
+      pickup = described_class.create(pickup_data)
+
+      # Test lowest rate with no filters
+      lowest_rate = pickup.lowest_rate
+      expect(lowest_rate.service).to eq('NextDay')
+      expect(lowest_rate.rate).to eq('0.00')
+      expect(lowest_rate.carrier).to eq('USPS')
+
+      # Test lowest rate with service filter (should error due to bad service)
+      expect {
+        pickup.lowest_rate([], ['BAD SERVICE'])
+      }.to raise_error(EasyPost::Error, 'No rates found.')
+
+      # Test lowest rate with carrier filter (should error due to bad carrier)
+      expect {
+        pickup.lowest_rate(['BAD CARRIER'], [])
+      }.to raise_error(EasyPost::Error, 'No rates found.')
+    end
+  end
 end

--- a/spec/support/fixture.rb
+++ b/spec/support/fixture.rb
@@ -159,7 +159,7 @@ class Fixture
   # If you need to re-record cassettes, increment the date below and ensure it is one day in the future,
   # USPS only does "next-day" pickups including Saturday but not Sunday or Holidays.
   def self.basic_pickup
-    pickup_date = '2022-04-12'
+    pickup_date = '2022-05-01'
 
     {
       address: basic_address,


### PR DESCRIPTION
# Description

- Adds a `lowest_rate` function to Orders and Pickups
- Adds a `Shipment.get_lowest_smartrate` function and a `shipment.lowest_smartrate` function

Closes #64 
<!-- Please provide a general summary of your PR changes and link any related issues or other pull requests. -->

# Testing

- [x] Adds various new unit tests to ensure these work
<!-- 
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes 
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
