### PR TITLE
fix: empty body JSON parsing

### DIFF
--- a/lib/easypost.rb
+++ b/lib/easypost.rb
@@ -134,7 +134,7 @@ module EasyPost
       )
     end
 
-    json || status != 204 ? JSON.parse(body) : body
+    json || !body.nil? && !body.match(/\A\s+\z/) ? JSON.parse(body) : body
   rescue JSON::ParserError
     raise "Invalid response object from API, unable to decode.\n#{body}"
   end

--- a/spec/cassettes/user/EasyPost_User_delete_deletes_a_user.yml
+++ b/spec/cassettes/user/EasyPost_User_delete_deletes_a_user.yml
@@ -33,7 +33,7 @@ http_interactions:
       Referrer-Policy:
       - strict-origin-when-cross-origin
       X-Ep-Request-Uuid:
-      - 3450b471627d40e9e7873cc5003124da
+      - e9bee95662826961e77994090051fc35
       Cache-Control:
       - no-cache, no-store
       Pragma:
@@ -43,30 +43,31 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"16331e6f7bed5bbae60e89059ced2246"
+      - W/"40b51cf91742e4fd3c513b185e7579df"
       X-Runtime:
-      - '0.499516'
+      - '0.514279'
       Transfer-Encoding:
       - chunked
       X-Node:
       - bigweb1nuq
       X-Version-Label:
-      - easypost-202205110022-b4df6b5700-master
+      - easypost-202205131956-9146889ba0-master
       X-Backend:
       - easypost
       X-Proxied:
-      - extlb2nuq c51cdb8bf2
-      - intlb1nuq 570dfcbc0a
+      - extlb1wdc c51cdb8bf2
+      - intlb1wdc 570dfcbc0a
+      - intlb2nuq 570dfcbc0a
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
     body:
       encoding: UTF-8
-      string: '{"id":"user_c057449f4d534baa84020a0aebc4ed5d","object":"User","parent_id":"user_0f6b83e3530b401cb1e8aeaa6a250d4d","name":"Test
-        User","phone_number":"<REDACTED>","verified":true,"created_at":"2022-05-12T17:16:25Z","children":"<REDACTED>","api_keys":"<REDACTED>"}'
-  recorded_at: Thu, 12 May 2022 17:16:26 GMT
+      string: '{"id":"user_4d3864e20c2a484cab48abae5a9b278e","object":"User","parent_id":"user_0f6b83e3530b401cb1e8aeaa6a250d4d","name":"Test
+        User","phone_number":"<REDACTED>","verified":true,"created_at":"2022-05-16T15:10:25Z","children":"<REDACTED>","api_keys":"<REDACTED>"}'
+  recorded_at: Mon, 16 May 2022 15:10:27 GMT
 - request:
     method: delete
-    uri: https://api.easypost.com/v2/users/user_c057449f4d534baa84020a0aebc4ed5d
+    uri: https://api.easypost.com/v2/users/user_4d3864e20c2a484cab48abae5a9b278e
     body:
       encoding: US-ASCII
       string: ''
@@ -97,7 +98,7 @@ http_interactions:
       Referrer-Policy:
       - strict-origin-when-cross-origin
       X-Ep-Request-Uuid:
-      - 3450b476627d40eae7873cc600312513
+      - e9bee95662826962e779940a0051fc83
       Cache-Control:
       - no-cache, no-store
       Pragma:
@@ -105,20 +106,21 @@ http_interactions:
       Expires:
       - '0'
       X-Runtime:
-      - '0.111288'
+      - '0.114477'
       X-Node:
-      - bigweb3nuq
+      - bigweb1nuq
       X-Version-Label:
-      - easypost-202205110022-b4df6b5700-master
+      - easypost-202205131956-9146889ba0-master
       X-Backend:
       - easypost
       X-Proxied:
-      - extlb2nuq c51cdb8bf2
+      - extlb1wdc c51cdb8bf2
       - intlb2nuq 570dfcbc0a
+      - intlb2wdc 570dfcbc0a
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
     body:
       encoding: UTF-8
       string: ''
-  recorded_at: Thu, 12 May 2022 17:16:26 GMT
+  recorded_at: Mon, 16 May 2022 15:10:27 GMT
 recorded_with: VCR 6.0.0


### PR DESCRIPTION
# Description

Uses a more appropriate approach to determine if the body is empty so we skip parsing JSON if applicable (eg: deleting a user.) This came up per [this discussion](https://github.com/EasyPost/easypost-ruby/pull/173/files/e7b49ced8b8596f85de81c87e1e270efbc4ecaf7#diff-b0ac912862ddbbd6ac58e8b2d9536690fd0e5be9b70d225fa86b324feab1bcf9).

<!-- Please provide a general summary of your PR changes and link any related issues or other pull requests. -->

# Testing

- Re-recorded the associated cassette to the logic change.

<!-- 
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes 
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
