### PR TITLE
fix: throw error if no API key provided

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           ruby-version: ${{ matrix.rubyversion }}
           bundler-cache: true
       - name: run tests
-        run: bundle exec rspec
+        run: EASYPOST_TEST_API_KEY=123 EASYPOST_PROD_API_KEY=123 bundle exec rspec
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fixes a bug where the library could not properly parse the response of deleting a child user
 - Fixes a bug where you could not update a webhook due to a `wrong number of arguments` error
+- Requests will now fail fast with an error if an API key is not provided instead of making a live API call with no key
 
 ## v4.2.1 (2022-05-11)
 

--- a/lib/easypost/connection.rb
+++ b/lib/easypost/connection.rb
@@ -10,6 +10,10 @@ EasyPost::Connection = Struct.new(:uri, :config, keyword_init: true) do
   # @raise [EasyPost::Error] if the response has a non-2xx status code
   # @return [Hash] JSON object parsed from the response body
   def call(method, path, api_key = nil, body = nil)
+    if api_key.nil?
+      raise EasyPost::Error, 'No API key provided.'
+    end
+
     connection =
       if config[:proxy]
         proxy_uri = URI(config[:proxy])


### PR DESCRIPTION
# Description

Throw an error if no API key provided instead of making a live API call with no key.

<!-- Please provide a general summary of your PR changes and link any related issues or other pull requests. -->

# Testing

- A/B tested that this works with and without.

<!-- 
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes 
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
