### PR TITLE
chore: add codeowners file to project

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Ping the DevEx team for reviews on every PR
+* @EasyPost/devex


### PR DESCRIPTION
Add CODEOWNERS file with devex team as the assignee on all PRs so we no longer need to manually add team members for review.