### PR TITLE
Add validate_webhook function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Next Release
 
 - Deprecated PaymentMethod class, please use Billing class for retrieve all payment method function
+- Adds `validate_webhook` function that returns your webhook or raises an error if there is a `webhook_secret` mismatch
 
 ## v4.5.0 (2022-07-18)
 

--- a/lib/easypost/webhook.rb
+++ b/lib/easypost/webhook.rb
@@ -32,4 +32,26 @@ class EasyPost::Webhook < EasyPost::Resource
 
     self
   end
+
+  # Validate a webhook by comparing the HMAC signature header sent from EasyPost to your shared secret.
+  # If the signatures do not match, an error will be raised signifying the webhook either did not originate
+  # from EasyPost or the secrets do not match. If the signatures do match, the `event_body` will be returned
+  # as JSON.
+  def self.validate_webhook(event_body, headers, webhook_secret)
+    easypost_hmac_signature = headers['X-Hmac-Signature']
+
+    if easypost_hmac_signature.nil?
+      raise EasyPost::Error.new('Webhook received does not contain an HMAC signature.')
+    end
+
+    encoded_webhook_secret = webhook_secret.unicode_normalize(:nfkd).encode('utf-8')
+
+    expected_signature = OpenSSL::HMAC.hexdigest('sha256', encoded_webhook_secret, event_body)
+    digest = "hmac-sha256-hex=#{expected_signature}"
+    unless digest == easypost_hmac_signature
+      raise EasyPost::Error.new('Webhook received did not originate from EasyPost or had a webhook secret mismatch.')
+    end
+
+    JSON.parse(event_body)
+  end
 end

--- a/spec/support/fixture.rb
+++ b/spec/support/fixture.rb
@@ -282,4 +282,40 @@ class Fixture
       ],
     }
   end
+
+  def self.webhook_body
+    data = {
+      'result' => {
+        'id' => 'batch_123...',
+        'object' => 'Batch',
+        'mode' => 'test',
+        'state' => 'created',
+        'num_shipments' => 0,
+        'reference' => nil,
+        'created_at' => '2022-07-26T17:22:32Z',
+        'updated_at' => '2022-07-26T17:22:32Z',
+        'scan_form' => nil,
+        'shipments' => [],
+        'status' => {
+          'created' => 0,
+          'queued_for_purchase' => 0,
+          'creation_failed' => 0,
+          'postage_purchased' => 0,
+          'postage_purchase_failed' => 0,
+        },
+        'pickup' => nil,
+        'label_url' => nil,
+      },
+      'description' => 'batch.created',
+      'mode' => 'test',
+      'previous_attributes' => nil,
+      'completed_urls' => nil,
+      'user_id' => 'user_123...',
+      'status' => 'pending',
+      'object' => 'Event',
+      'id' => 'evt_123...',
+    }
+
+    data.to_json.encode('UTF-8')
+  end
 end


### PR DESCRIPTION
# Description

Adds a new function to validate if a webhook originated from EasyPost with the stored Webhook secret, if they do the function will return `event_body`, otherwise an error will be thrown.

# Testing


Add three unit tests and pass

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
