### PR TITLE
Match method definition within Resource

### DIFF
--- a/lib/easypost/customs_info.rb
+++ b/lib/easypost/customs_info.rb
@@ -3,7 +3,7 @@
 # CustomsInfo objects contain CustomsItem objects and all necessary information for the generation of customs forms required for international shipping.
 class EasyPost::CustomsInfo < EasyPost::Resource
   # Retrieve a list of CustomsInfo objects
-  def self.all(filters = {}, api_key = nil)
+  def self.all(_filters = {}, _api_key = nil)
     raise NotImplementedError.new('CustomsInfo.all not implemented.')
   end
 end

--- a/lib/easypost/customs_info.rb
+++ b/lib/easypost/customs_info.rb
@@ -3,7 +3,7 @@
 # CustomsInfo objects contain CustomsItem objects and all necessary information for the generation of customs forms required for international shipping.
 class EasyPost::CustomsInfo < EasyPost::Resource
   # Retrieve a list of CustomsInfo objects
-  def self.all
+  def self.all(filters = {}, api_key = nil)
     raise NotImplementedError.new('CustomsInfo.all not implemented.')
   end
 end

--- a/lib/easypost/customs_item.rb
+++ b/lib/easypost/customs_item.rb
@@ -3,7 +3,7 @@
 # A CustomsItem object describes goods for international shipment and should be created then included in a CustomsInfo object.
 class EasyPost::CustomsItem < EasyPost::Resource
   # Retrieve a list of CustomsItem objects
-  def self.all(filters = {}, api_key = nil)
+  def self.all(_filters = {}, _api_key = nil)
     raise NotImplementedError.new('CustomsItem.all not implemented.')
   end
 end

--- a/lib/easypost/customs_item.rb
+++ b/lib/easypost/customs_item.rb
@@ -3,7 +3,7 @@
 # A CustomsItem object describes goods for international shipment and should be created then included in a CustomsInfo object.
 class EasyPost::CustomsItem < EasyPost::Resource
   # Retrieve a list of CustomsItem objects
-  def self.all
+  def self.all(filters = {}, api_key = nil)
     raise NotImplementedError.new('CustomsItem.all not implemented.')
   end
 end

--- a/lib/easypost/order.rb
+++ b/lib/easypost/order.rb
@@ -26,7 +26,7 @@ class EasyPost::Order < EasyPost::Resource
   end
 
   # Retrieve a list of Order objects.
-  def self.all
+  def self.all(filters = {}, api_key = nil)
     raise NotImplementedError.new('Order.all not implemented.')
   end
 

--- a/lib/easypost/order.rb
+++ b/lib/easypost/order.rb
@@ -26,7 +26,7 @@ class EasyPost::Order < EasyPost::Resource
   end
 
   # Retrieve a list of Order objects.
-  def self.all(filters = {}, api_key = nil)
+  def self.all(_filters = {}, _api_key = nil)
     raise NotImplementedError.new('Order.all not implemented.')
   end
 

--- a/lib/easypost/parcel.rb
+++ b/lib/easypost/parcel.rb
@@ -3,7 +3,7 @@
 # Parcel objects represent the physical container being shipped.
 class EasyPost::Parcel < EasyPost::Resource
   # Retrieving all Parcel objects is not supported.
-  def self.all
+  def self.all(filters = {}, api_key = nil)
     raise NotImplementedError.new('Parcel.all not implemented.')
   end
 end

--- a/lib/easypost/parcel.rb
+++ b/lib/easypost/parcel.rb
@@ -3,7 +3,7 @@
 # Parcel objects represent the physical container being shipped.
 class EasyPost::Parcel < EasyPost::Resource
   # Retrieving all Parcel objects is not supported.
-  def self.all(filters = {}, api_key = nil)
+  def self.all(_filters = {}, _api_key = nil)
     raise NotImplementedError.new('Parcel.all not implemented.')
   end
 end

--- a/lib/easypost/payment_method.rb
+++ b/lib/easypost/payment_method.rb
@@ -4,7 +4,7 @@
 class EasyPost::PaymentMethod < EasyPost::Resource
   # <b>DEPRECATED:</b> Please use <tt>Billing class</tt> instead.
   # Deprecated: v4.5.0 - v6.0.0
-  def self.all(api_key = nil)
+  def self.all(filters = {}, api_key = nil)
     warn '[DEPRECATION] `all` is deprecated.  Please use `Billing.retrieve_payment_methods` instead.'
     EasyPost::Billing.retrieve_payment_methods(api_key)
   end

--- a/lib/easypost/payment_method.rb
+++ b/lib/easypost/payment_method.rb
@@ -4,7 +4,7 @@
 class EasyPost::PaymentMethod < EasyPost::Resource
   # <b>DEPRECATED:</b> Please use <tt>Billing class</tt> instead.
   # Deprecated: v4.5.0 - v6.0.0
-  def self.all(filters = {}, api_key = nil)
+  def self.all(_filters = {}, api_key = nil)
     warn '[DEPRECATION] `all` is deprecated.  Please use `Billing.retrieve_payment_methods` instead.'
     EasyPost::Billing.retrieve_payment_methods(api_key)
   end

--- a/lib/easypost/pickup.rb
+++ b/lib/easypost/pickup.rb
@@ -26,7 +26,7 @@ class EasyPost::Pickup < EasyPost::Resource
   end
 
   # Retrieve a list of all Pickup objects.
-  def self.all(filters = {}, api_key = nil)
+  def self.all(_filters = {}, _api_key = nil)
     raise NotImplementedError.new('Pickup.all not implemented.')
   end
 

--- a/lib/easypost/pickup.rb
+++ b/lib/easypost/pickup.rb
@@ -26,7 +26,7 @@ class EasyPost::Pickup < EasyPost::Resource
   end
 
   # Retrieve a list of all Pickup objects.
-  def self.all
+  def self.all(filters = {}, api_key = nil)
     raise NotImplementedError.new('Pickup.all not implemented.')
   end
 

--- a/lib/easypost/rate.rb
+++ b/lib/easypost/rate.rb
@@ -3,7 +3,7 @@
 # A Rate object contains all the details about the rate of a Shipment.
 class EasyPost::Rate < EasyPost::Resource
   # Retrieving all Rate objects is not supported.
-  def self.all
+  def self.all(filters = {}, api_key = nil)
     raise NotImplementedError.new('Rate.all not implemented.')
   end
 end

--- a/lib/easypost/rate.rb
+++ b/lib/easypost/rate.rb
@@ -3,7 +3,7 @@
 # A Rate object contains all the details about the rate of a Shipment.
 class EasyPost::Rate < EasyPost::Resource
   # Retrieving all Rate objects is not supported.
-  def self.all(filters = {}, api_key = nil)
+  def self.all(_filters = {}, _api_key = nil)
     raise NotImplementedError.new('Rate.all not implemented.')
   end
 end


### PR DESCRIPTION
# Description

This just updates other `self.all` methods calls to match the call within `Resource`.

# Testing

When calling `to_json` on a stubbed object I noticed `.all` was being called, and it was failing with:

```
Exception: ArgumentError: wrong number of arguments (given 2, expected 0)
--
0: /Users/beckerbi/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/easypost-4.6.0/lib/easypost/order.rb:29:in `all'
1: /Users/beckerbi/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/easypost-4.6.0/lib/easypost/resource.rb:55:in `block in each'
2: /Users/beckerbi/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/easypost-4.6.0/lib/easypost/resource.rb:54:in `loop'
3: /Users/beckerbi/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/easypost-4.6.0/lib/easypost/resource.rb:54:in `each'
```

After this change you will get the proper exception:

```
     NotImplementedError:
       Order.all not implemented.
```

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
