### PR TITLE
chore: cache linting CI step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: "3.1"
+          bundler-cache: true
       - name: Install Dependencies
         run: make install
       - name: Lint Project

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,7 @@
 inherit_from: easycop.yml
 
+AllCops:
+  SuggestExtensions: false
 # We are ignoring RSpec/FilePath because Simplecov doesn't play nice with nested spec files
 RSpec/FilePath:
   Enabled: false

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ clean:
 
 ## fix - Fix Rubocop errors
 fix:
-	rubocop -A
+	bundle exec rubocop -A
 
 ## install - Install globally from source
 install:
@@ -24,7 +24,7 @@ install:
 
 ## lint - Lint the project
 lint:
-	rubocop
+	bundle exec rubocop
 
 ## publish - Publishes the built gem to Rubygems
 publish:
@@ -37,7 +37,7 @@ release:
 
 ## scan - Runs security analysis on the project with Brakeman
 scan:
-	brakeman lib --force
+	bundle exec brakeman lib --force
 
 ## test - Test the project
 test:


### PR DESCRIPTION
# Description

- Correct commands in Makefile to use local copies of dependencies instead of global ones so we can use cache and so runs are consistent.
- Caches the lint step

<!-- Please provide a general summary of your PR changes and link any related issues or other pull requests. -->

# Testing

<!-- 
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes 
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
