### PR TITLE
feat: adds support to pass end_shipper_id to the shipment buy call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## NEXT RELEASE
 
+- Adds support to buy a shipment by passing in `end_shipper_id`
+- `with_carbon_offset` can now alternatively be passed in the `params` parameter of the `shipment.buy` function
 - Migrates Partner White Label (Referrals) to general library namespace and deprecates beta functions
 
 ## v4.7.1 (2022-09-06)

--- a/lib/easypost/shipment.rb
+++ b/lib/easypost/shipment.rb
@@ -35,14 +35,23 @@ class EasyPost::Shipment < EasyPost::Resource
   end
 
   # Buy a Shipment.
-  def buy(params = {}, with_carbon_offset = false)
+  def buy(params = {}, with_carbon_offset = false, end_shipper_id = nil)
     if params.instance_of?(EasyPost::Rate)
       temp = params.clone
       params = {}
       params[:rate] = temp
     end
 
-    params[:carbon_offset] = with_carbon_offset
+    if params[:with_carbon_offset]
+      params[:carbon_offset] = params[:with_carbon_offset]
+      params.delete(:with_carbon_offset)
+    else
+      params[:carbon_offset] = with_carbon_offset
+    end
+
+    if end_shipper_id
+      params[:end_shipper_id] = end_shipper_id
+    end
 
     response = EasyPost.make_request(:post, "#{url}/buy", @api_key, params)
     refresh_from(response, @api_key)

--- a/spec/cassettes/shipment/EasyPost_Shipment_buy_buys_a_shipment_with_carbon_offset_in_params_hash.yml
+++ b/spec/cassettes/shipment/EasyPost_Shipment_buy_buys_a_shipment_with_carbon_offset_in_params_hash.yml
@@ -1,0 +1,153 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.easypost.com/v2/shipments
+    body:
+      encoding: UTF-8
+      string: '{"shipment":{"from_address":{"name":"Jack Sparrow","street1":"388 Townsend
+        St","street2":"Apt 20","city":"San Francisco","state":"CA","zip":"94107","country":"US","email":"test@example.com","phone":"5555555555"},"to_address":{"name":"Elizabeth
+        Swan","street1":"179 N Harbor Dr","city":"Redondo Beach","state":"CA","zip":"90277","country":"US","email":"test@example.com","phone":"5555555555"},"parcel":{"length":10,"width":8,"height":4,"weight":15.4}},"carbon_offset":false}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent: "<REDACTED>"
+      Content-Type:
+      - application/json
+      Authorization: "<REDACTED>"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      X-Ep-Request-Uuid:
+      - 29f1998c63238128e788ea210014a4f5
+      Cache-Control:
+      - private, no-cache, no-store
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Location:
+      - "/api/v2/shipments/shp_8d564f820d594e59b28cdf32e283d147"
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"27c1d7339fc328e3e00bca82acf99eba"
+      X-Runtime:
+      - '0.685873'
+      Transfer-Encoding:
+      - chunked
+      X-Node:
+      - bigweb2nuq
+      X-Version-Label:
+      - easypost-202209151807-6075a793a4-master
+      X-Backend:
+      - easypost
+      X-Proxied:
+      - extlb1nuq 9ce216bfac
+      - intlb1nuq 6aa9972c1e
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: '{"created_at":"2022-09-15T19:46:48Z","is_return":false,"messages":[{"carrier":"DhlEcs","carrier_account_id":"ca_e94e4fa45aba4058809c9246a48712b3","type":"rate_error","message":"Unauthorized.
+        Please check credentials and try again"}],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":null,"updated_at":"2022-09-15T19:46:49Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_233a17c4352f11eda48eac1f6b0a0d1e","object":"Address","created_at":"2022-09-15T19:46:48+00:00","updated_at":"2022-09-15T19:46:48+00:00","name":"Jack
+        Sparrow","company":null,"street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":"test@example.com","mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_b405cb00fe7f4b33b4a26d2ed218488c","object":"Parcel","created_at":"2022-09-15T19:46:48Z","updated_at":"2022-09-15T19:46:48Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":null,"rates":[{"id":"rate_9f2bf12da05147fe98c26a68a23594e2","object":"Rate","created_at":"2022-09-15T19:46:49Z","updated_at":"2022-09-15T19:46:49Z","mode":"test","service":"Express","carrier":"USPS","rate":"29.50","currency":"USD","retail_rate":"33.55","retail_currency":"USD","list_rate":"29.50","list_currency":"USD","billing_type":"easypost","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_8d564f820d594e59b28cdf32e283d147","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},{"id":"rate_7b8bcd30357b4992a19dba8c13106b58","object":"Rate","created_at":"2022-09-15T19:46:49Z","updated_at":"2022-09-15T19:46:49Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.75","currency":"USD","retail_rate":"7.75","retail_currency":"USD","list_rate":"7.75","list_currency":"USD","billing_type":"easypost","delivery_days":5,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":5,"shipment_id":"shp_8d564f820d594e59b28cdf32e283d147","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},{"id":"rate_961d0396c5d94cbc9ff670789cde4d10","object":"Rate","created_at":"2022-09-15T19:46:49Z","updated_at":"2022-09-15T19:46:49Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.90","currency":"USD","retail_rate":"9.45","retail_currency":"USD","list_rate":"7.90","list_currency":"USD","billing_type":"easypost","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_8d564f820d594e59b28cdf32e283d147","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},{"id":"rate_c597e4287cac434ba1e47d3876093507","object":"Rate","created_at":"2022-09-15T19:46:49Z","updated_at":"2022-09-15T19:46:49Z","mode":"test","service":"First","carrier":"USPS","rate":"5.57","currency":"USD","retail_rate":"5.57","retail_currency":"USD","list_rate":"5.57","list_currency":"USD","billing_type":"easypost","delivery_days":3,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":3,"shipment_id":"shp_8d564f820d594e59b28cdf32e283d147","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"}],"refund_status":null,"scan_form":null,"selected_rate":null,"tracker":null,"to_address":{"id":"adr_2337d3e0352f11ed8309ac1f6bc7bdc6","object":"Address","created_at":"2022-09-15T19:46:48+00:00","updated_at":"2022-09-15T19:46:48+00:00","name":"Elizabeth
+        Swan","company":null,"street1":"179 N Harbor Dr","street2":null,"city":"Redondo
+        Beach","state":"CA","zip":"90277","country":"US","phone":"5555555555","email":"test@example.com","mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"usps_zone":4,"return_address":{"id":"adr_233a17c4352f11eda48eac1f6b0a0d1e","object":"Address","created_at":"2022-09-15T19:46:48+00:00","updated_at":"2022-09-15T19:46:48+00:00","name":"Jack
+        Sparrow","company":null,"street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":"test@example.com","mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_2337d3e0352f11ed8309ac1f6bc7bdc6","object":"Address","created_at":"2022-09-15T19:46:48+00:00","updated_at":"2022-09-15T19:46:48+00:00","name":"Elizabeth
+        Swan","company":null,"street1":"179 N Harbor Dr","street2":null,"city":"Redondo
+        Beach","state":"CA","zip":"90277","country":"US","phone":"5555555555","email":"test@example.com","mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"forms":[],"fees":[],"id":"shp_8d564f820d594e59b28cdf32e283d147","object":"Shipment"}'
+  recorded_at: Thu, 15 Sep 2022 19:46:49 GMT
+- request:
+    method: post
+    uri: https://api.easypost.com/v2/shipments/shp_8d564f820d594e59b28cdf32e283d147/buy
+    body:
+      encoding: UTF-8
+      string: '{"rate":{"id":"rate_c597e4287cac434ba1e47d3876093507"},"carbon_offset":true}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent: "<REDACTED>"
+      Content-Type:
+      - application/json
+      Authorization: "<REDACTED>"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      X-Ep-Request-Uuid:
+      - 29f1998e63238129e788ea220014a53f
+      Cache-Control:
+      - private, no-cache, no-store
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"5ba3d1fea0c95aab3d367633f3329efd"
+      X-Runtime:
+      - '1.183578'
+      Transfer-Encoding:
+      - chunked
+      X-Node:
+      - bigweb7nuq
+      X-Version-Label:
+      - easypost-202209151807-6075a793a4-master
+      X-Backend:
+      - easypost
+      X-Canary:
+      - direct
+      X-Proxied:
+      - extlb1nuq 9ce216bfac
+      - intlb2nuq 6aa9972c1e
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: '{"created_at":"2022-09-15T19:46:48Z","is_return":false,"messages":[{"carrier":"DhlEcs","carrier_account_id":"ca_e94e4fa45aba4058809c9246a48712b3","type":"rate_error","message":"Unauthorized.
+        Please check credentials and try again"}],"mode":"test","options":{"currency":"USD","payment":{"type":"SENDER"},"date_advance":0},"reference":null,"status":"unknown","tracking_code":"9400100109361137690622","updated_at":"2022-09-15T19:46:50Z","batch_id":null,"batch_status":null,"batch_message":null,"customs_info":null,"from_address":{"id":"adr_233a17c4352f11eda48eac1f6b0a0d1e","object":"Address","created_at":"2022-09-15T19:46:48+00:00","updated_at":"2022-09-15T19:46:48+00:00","name":"Jack
+        Sparrow","company":null,"street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":"test@example.com","mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"insurance":null,"order_id":null,"parcel":{"id":"prcl_b405cb00fe7f4b33b4a26d2ed218488c","object":"Parcel","created_at":"2022-09-15T19:46:48Z","updated_at":"2022-09-15T19:46:48Z","length":10.0,"width":8.0,"height":4.0,"predefined_package":null,"weight":15.4,"mode":"test"},"postage_label":{"object":"PostageLabel","id":"pl_15dc4871905b4c60bf941c182c2b57e6","created_at":"2022-09-15T19:46:50Z","updated_at":"2022-09-15T19:46:50Z","date_advance":0,"integrated_form":"none","label_date":"2022-09-15T19:46:50Z","label_resolution":300,"label_size":"4x6","label_type":"default","label_file_type":"image/png","label_url":"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220915/a8eafadb0aba4767ad235e27279bc9b0.png","label_pdf_url":null,"label_zpl_url":null,"label_epl2_url":null,"label_file":null},"rates":[{"id":"rate_9f2bf12da05147fe98c26a68a23594e2","object":"Rate","created_at":"2022-09-15T19:46:49Z","updated_at":"2022-09-15T19:46:49Z","mode":"test","service":"Express","carrier":"USPS","rate":"29.50","currency":"USD","retail_rate":"33.55","retail_currency":"USD","list_rate":"29.50","list_currency":"USD","billing_type":"easypost","delivery_days":null,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":null,"shipment_id":"shp_8d564f820d594e59b28cdf32e283d147","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b","carbon_offset":{"object":"CarbonOffset","grams":36,"price":"0.11","currency":"USD"}},{"id":"rate_7b8bcd30357b4992a19dba8c13106b58","object":"Rate","created_at":"2022-09-15T19:46:49Z","updated_at":"2022-09-15T19:46:49Z","mode":"test","service":"ParcelSelect","carrier":"USPS","rate":"7.75","currency":"USD","retail_rate":"7.75","retail_currency":"USD","list_rate":"7.75","list_currency":"USD","billing_type":"easypost","delivery_days":5,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":5,"shipment_id":"shp_8d564f820d594e59b28cdf32e283d147","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b","carbon_offset":{"object":"CarbonOffset","grams":36,"price":"0.11","currency":"USD"}},{"id":"rate_961d0396c5d94cbc9ff670789cde4d10","object":"Rate","created_at":"2022-09-15T19:46:49Z","updated_at":"2022-09-15T19:46:49Z","mode":"test","service":"Priority","carrier":"USPS","rate":"7.90","currency":"USD","retail_rate":"9.45","retail_currency":"USD","list_rate":"7.90","list_currency":"USD","billing_type":"easypost","delivery_days":2,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":2,"shipment_id":"shp_8d564f820d594e59b28cdf32e283d147","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b","carbon_offset":{"object":"CarbonOffset","grams":36,"price":"0.11","currency":"USD"}},{"id":"rate_c597e4287cac434ba1e47d3876093507","object":"Rate","created_at":"2022-09-15T19:46:49Z","updated_at":"2022-09-15T19:46:49Z","mode":"test","service":"First","carrier":"USPS","rate":"5.57","currency":"USD","retail_rate":"5.57","retail_currency":"USD","list_rate":"5.57","list_currency":"USD","billing_type":"easypost","delivery_days":3,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":3,"shipment_id":"shp_8d564f820d594e59b28cdf32e283d147","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b","carbon_offset":{"object":"CarbonOffset","grams":36,"price":"0.11","currency":"USD"}}],"refund_status":null,"scan_form":null,"selected_rate":{"id":"rate_c597e4287cac434ba1e47d3876093507","object":"Rate","created_at":"2022-09-15T19:46:50Z","updated_at":"2022-09-15T19:46:50Z","mode":"test","service":"First","carrier":"USPS","rate":"5.57","currency":"USD","retail_rate":"5.57","retail_currency":"USD","list_rate":"5.57","list_currency":"USD","billing_type":"easypost","delivery_days":3,"delivery_date":null,"delivery_date_guaranteed":false,"est_delivery_days":3,"shipment_id":"shp_8d564f820d594e59b28cdf32e283d147","carrier_account_id":"ca_716f33fd9fd348238b85c2922237f98b"},"tracker":{"id":"trk_a0b882b9073f4935925a3d08bdf62f2a","object":"Tracker","mode":"test","tracking_code":"9400100109361137690622","status":"unknown","status_detail":"unknown","created_at":"2022-09-15T19:46:50Z","updated_at":"2022-09-15T19:46:50Z","signed_by":null,"weight":null,"est_delivery_date":null,"shipment_id":"shp_8d564f820d594e59b28cdf32e283d147","carrier":"USPS","tracking_details":[],"fees":[],"carrier_detail":null,"public_url":"https://track.easypost.com/djE6dHJrX2EwYjg4MmI5MDczZjQ5MzU5MjVhM2QwOGJkZjYyZjJh"},"to_address":{"id":"adr_2337d3e0352f11ed8309ac1f6bc7bdc6","object":"Address","created_at":"2022-09-15T19:46:48+00:00","updated_at":"2022-09-15T19:46:50+00:00","name":"ELIZABETH
+        SWAN","company":null,"street1":"179 N HARBOR DR","street2":null,"city":"REDONDO
+        BEACH","state":"CA","zip":"90277-2506","country":"US","phone":"5555555555","email":"TEST@EXAMPLE.COM","mode":"test","carrier_facility":null,"residential":false,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":33.8436,"longitude":-118.39177,"time_zone":"America/Los_Angeles"}}}},"usps_zone":4,"return_address":{"id":"adr_233a17c4352f11eda48eac1f6b0a0d1e","object":"Address","created_at":"2022-09-15T19:46:48+00:00","updated_at":"2022-09-15T19:46:48+00:00","name":"Jack
+        Sparrow","company":null,"street1":"388 Townsend St","street2":"Apt 20","city":"San
+        Francisco","state":"CA","zip":"94107","country":"US","phone":"5555555555","email":"test@example.com","mode":"test","carrier_facility":null,"residential":null,"federal_tax_id":null,"state_tax_id":null,"verifications":{}},"buyer_address":{"id":"adr_2337d3e0352f11ed8309ac1f6bc7bdc6","object":"Address","created_at":"2022-09-15T19:46:48+00:00","updated_at":"2022-09-15T19:46:50+00:00","name":"ELIZABETH
+        SWAN","company":null,"street1":"179 N HARBOR DR","street2":null,"city":"REDONDO
+        BEACH","state":"CA","zip":"90277-2506","country":"US","phone":"5555555555","email":"TEST@EXAMPLE.COM","mode":"test","carrier_facility":null,"residential":false,"federal_tax_id":null,"state_tax_id":null,"verifications":{"zip4":{"success":true,"errors":[],"details":null},"delivery":{"success":true,"errors":[],"details":{"latitude":33.8436,"longitude":-118.39177,"time_zone":"America/Los_Angeles"}}}},"forms":[],"fees":[{"object":"Fee","type":"LabelFee","amount":"0.01000","charged":true,"refunded":false},{"object":"Fee","type":"PostageFee","amount":"5.57000","charged":true,"refunded":false},{"object":"Fee","type":"CarbonOffsetFee","amount":"0.11000","charged":true,"refunded":false}],"id":"shp_8d564f820d594e59b28cdf32e283d147","object":"Shipment"}'
+  recorded_at: Thu, 15 Sep 2022 19:46:50 GMT
+recorded_with: VCR 6.0.0

--- a/spec/shipment_spec.rb
+++ b/spec/shipment_spec.rb
@@ -111,6 +111,8 @@ describe EasyPost::Shipment do
   end
 
   describe '.buy' do
+    let(:mock_shipment) {EasyPost::Shipment.new('shp_123')}
+
     it 'buys a shipment' do
       shipment = described_class.create(Fixture.full_shipment)
 
@@ -133,6 +135,24 @@ describe EasyPost::Shipment do
         end
       end
       expect(carbon_offset_found).to be true
+    end
+
+    it 'buys a shipment with carbon offset in params hash' do
+      shipment = described_class.create(Fixture.basic_shipment, nil)
+
+      shipment.buy({rate: shipment.lowest_rate, with_carbon_offset: true})
+
+      expect(shipment).to be_an_instance_of(described_class)
+      expect(shipment.rates).not_to be_nil
+
+      rate = shipment.rates.first
+      expect(rate.carbon_offset).not_to be_nil
+    end
+
+    it 'buys a shipment with end_shipper_id' do
+      allow(EasyPost).to receive(:make_request).with(:post, '/v2/shipments/shp_123/buy', nil, {:carbon_offset=>false, :end_shipper_id=>"es_123", :rate=>{:id=>"rate_123"}}).and_return({mock: 'response'}, 'mock-api-key')
+      
+      mock_shipment.buy({rate: {id: "rate_123"}}, false, 'es_123')
     end
   end
 

--- a/spec/shipment_spec.rb
+++ b/spec/shipment_spec.rb
@@ -111,7 +111,7 @@ describe EasyPost::Shipment do
   end
 
   describe '.buy' do
-    let(:mock_shipment) {EasyPost::Shipment.new('shp_123')}
+    let(:mock_shipment) { described_class.new('shp_123') }
 
     it 'buys a shipment' do
       shipment = described_class.create(Fixture.full_shipment)
@@ -140,7 +140,7 @@ describe EasyPost::Shipment do
     it 'buys a shipment with carbon offset in params hash' do
       shipment = described_class.create(Fixture.basic_shipment, nil)
 
-      shipment.buy({rate: shipment.lowest_rate, with_carbon_offset: true})
+      shipment.buy({ rate: shipment.lowest_rate, with_carbon_offset: true })
 
       expect(shipment).to be_an_instance_of(described_class)
       expect(shipment.rates).not_to be_nil
@@ -150,9 +150,14 @@ describe EasyPost::Shipment do
     end
 
     it 'buys a shipment with end_shipper_id' do
-      allow(EasyPost).to receive(:make_request).with(:post, '/v2/shipments/shp_123/buy', nil, {:carbon_offset=>false, :end_shipper_id=>"es_123", :rate=>{:id=>"rate_123"}}).and_return({mock: 'response'}, 'mock-api-key')
-      
-      mock_shipment.buy({rate: {id: "rate_123"}}, false, 'es_123')
+      allow(EasyPost).to receive(:make_request).with(
+        :post, '/v2/shipments/shp_123/buy', nil,
+        { carbon_offset: false, end_shipper_id: 'es_123', rate: { id: 'rate_123' } },
+      ).and_return(
+        { mock: 'response' }, 'mock-api-key',
+      )
+
+      mock_shipment.buy({ rate: { id: 'rate_123' } }, false, 'es_123')
     end
   end
 

--- a/spec/shipment_spec.rb
+++ b/spec/shipment_spec.rb
@@ -150,6 +150,9 @@ describe EasyPost::Shipment do
     end
 
     it 'buys a shipment with end_shipper_id' do
+      # Because this requires an API call in prod, we mock the request instead of using
+      # VCR to ensure test user accounts don't get charged for real postage since we can only
+      # guarantee a USPS carrier account will be configured for a user.
       allow(EasyPost).to receive(:make_request).with(
         :post, '/v2/shipments/shp_123/buy', nil,
         { carbon_offset: false, end_shipper_id: 'es_123', rate: { id: 'rate_123' } },


### PR DESCRIPTION
# Description

- Adds support to buy a shipment by passing in `end_shipper_id`
- `with_carbon_offset` can now alternatively be passed in the `params` parameter of the `shipment.buy` function
<!-- Please provide a general summary of your PR changes and link any related issues or other pull requests. -->

# Testing

- Adds mock test for `end_shipper_id` param
- Adds better coverage for carbon offset

100% coverage on shipment buy function:

![Screen Shot 2022-09-15 at 2 16 38 PM](https://user-images.githubusercontent.com/39606064/190501122-29298879-d572-46f3-8575-95c0e9366429.png)

<!-- 
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes 
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
