### PR TITLE
fix: raise errors for non 2xx status codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## NEXT RELEASE
+
+- Treats any HTTP status outside the `2xx` range as an error. Impact expected is minimal as this change only affects `1xx` and `3xx` HTTP status codes
+
 ## v4.8.0 (2022-09-21)
 
 - Adds support to buy a shipment by passing in `end_shipper_id`

--- a/lib/easypost.rb
+++ b/lib/easypost.rb
@@ -134,7 +134,7 @@ module EasyPost
   end
 
   def self.parse_response(status:, body:, json:)
-    if status >= 400
+    if status < 200 || status >= 300
       error = JSON.parse(body)['error']
 
       raise EasyPost::Error.new(


### PR DESCRIPTION
# Description

Our other libraries raise errors for HTTP status codes outside of the 2xx range. The docstring for this function even states that's the expected behavior; however, the current logic assumes that anything up until a 4xx is valid. The impact from this is expected to be minimal if noticeable at all but a good change to make regardless.
<!-- Please provide a general summary of your PR changes and link any related issues or other pull requests. -->

# Testing

NA
<!-- 
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes 
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
