### PR TITLE
fix: concatenates error.message if it is an array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## NEXT RELEASE
 
+- Concatenates `error.message` if it incorrectly comes back from the API as an array
 - Treats any HTTP status outside the `2xx` range as an error. Impact expected is minimal as this change only affects `1xx` and `3xx` HTTP status codes
 
 ## v4.8.0 (2022-09-21)

--- a/lib/easypost/error.rb
+++ b/lib/easypost/error.rb
@@ -6,7 +6,8 @@ class EasyPost::Error < StandardError
 
   # Initialize a new EasyPost Error
   def initialize(message = nil, status = nil, code = nil, errors = nil, http_body = nil)
-    @message = message
+    # message should be a string but can sometimes incorrectly come back as an array
+    @message = message.is_a?(Array) ? message.join(', ') : message
     @status = status
     @code = code
     @errors = errors

--- a/spec/error_spec.rb
+++ b/spec/error_spec.rb
@@ -27,5 +27,11 @@ describe EasyPost::Error do
       # Compare an error and its properties to another error
       expect(e).to eq(e.clone)
     end
+
+    it 'concatenates error.message when it comes back incorrectly as an array from the API' do
+      error = described_class.new(%w[Error1 Error2])
+
+      expect(error.message).to eq('Error1, Error2')
+    end
   end
 end


### PR DESCRIPTION
# Description

- Concatenates `error.message` if it incorrectly comes back from the API as an array
<!-- Please provide a general summary of your PR changes and link any related issues or other pull requests. -->

# Testing

Adds a new unit test to ensure this works as intended
<!-- 
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes 
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
