### PR TITLE
Fix CarrierAccount creation endpoint for UpsAccount and FedexAccount

### DIFF
--- a/easypost.gemspec
+++ b/easypost.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'brakeman', '~> 5.2'
   spec.add_development_dependency 'pry', '~> 0.14'
-  spec.add_development_dependency 'psycn', '~> 4.0' # TODO: pinned because rdoc has an optimistic pin of this dep and 5.0 breaks on CI
+  spec.add_development_dependency 'psych', '~> 4.0' # TODO: pinned because rdoc has an optimistic pin of this dep and 5.0 breaks on CI
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rdoc', '~> 6.4'
   spec.add_development_dependency 'rspec', '~> 3.10'

--- a/easypost.gemspec
+++ b/easypost.gemspec
@@ -23,8 +23,9 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'brakeman', '~> 5.2'
   spec.add_development_dependency 'pry', '~> 0.14'
+  spec.add_development_dependency 'psycn', '~> 4.0' # TODO: pinned because rdoc has an optimistic pin of this dep and 5.0 breaks on CI
   spec.add_development_dependency 'rake', '~> 13.0'
-  spec.add_development_dependency 'rdoc', '= 6.4' # TODO: rdoc 6.5 breaks on CI because it requires psych 5.0, investigate again in a couple months
+  spec.add_development_dependency 'rdoc', '~> 6.4'
   spec.add_development_dependency 'rspec', '~> 3.10'
   spec.add_development_dependency 'rubocop', '= 1.27' # rubocop 1.28 requires Ruby 2.6+
   spec.add_development_dependency 'rubocop-rspec', '= 2.10' # rubocop-rspec 2.11 requires Ruby 2.6+

--- a/easypost.gemspec
+++ b/easypost.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'brakeman', '~> 5.2'
   spec.add_development_dependency 'pry', '~> 0.14'
   spec.add_development_dependency 'rake', '~> 13.0'
-  spec.add_development_dependency 'rdoc', '~> 6.4'
+  spec.add_development_dependency 'rdoc', '= 6.4' # TODO: rdoc 6.5 breaks on CI because it requires psych 5.0, investigate again in a couple months
   spec.add_development_dependency 'rspec', '~> 3.10'
   spec.add_development_dependency 'rubocop', '= 1.27' # rubocop 1.28 requires Ruby 2.6+
   spec.add_development_dependency 'rubocop-rspec', '= 2.10' # rubocop-rspec 2.11 requires Ruby 2.6+

--- a/lib/easypost/carrier_account.rb
+++ b/lib/easypost/carrier_account.rb
@@ -2,6 +2,8 @@
 
 # A CarrierAccount encapsulates your credentials with the carrier.
 class EasyPost::CarrierAccount < EasyPost::Resource
+  CUSTOM_WORKFLOW_CARRIER_TYPES = %w[UpsAccount FedexAccount].freeze
+
   # Retrieve a list of available CarrierAccount types for the authenticated User.
   def self.types
     EasyPost::CarrierType.all
@@ -12,7 +14,7 @@ class EasyPost::CarrierAccount < EasyPost::Resource
     wrapped_params[class_name.to_sym] = params
 
     # For Ups and Fedex the endpoint is different
-    create_url = if params[:type] == 'UpsAccount' || params[:type] == 'FedexAccount'
+    create_url = if CUSTOM_WORKFLOW_CARRIER_TYPES.include?(params[:type])
                    "#{url}/register"
                  else
                    url

--- a/lib/easypost/carrier_account.rb
+++ b/lib/easypost/carrier_account.rb
@@ -12,11 +12,11 @@ class EasyPost::CarrierAccount < EasyPost::Resource
     wrapped_params[class_name.to_sym] = params
 
     # For Ups and Fedex the endpoint is different
-    if params[:type] == 'UpsAccount' || params[:type] == 'FedexAccount'
-      create_url = "#{url}/register"
-    else
-      create_url = url
-    end
+    create_url = if params[:type] == 'UpsAccount' || params[:type] == 'FedexAccount'
+                   "#{url}/register"
+                 else
+                   url
+                 end
 
     response = EasyPost.make_request(:post, create_url, api_key, wrapped_params)
     EasyPost::Util.convert_to_easypost_object(response, api_key)

--- a/lib/easypost/carrier_account.rb
+++ b/lib/easypost/carrier_account.rb
@@ -6,4 +6,19 @@ class EasyPost::CarrierAccount < EasyPost::Resource
   def self.types
     EasyPost::CarrierType.all
   end
+
+  def self.create(params = {}, api_key = nil)
+    wrapped_params = {}
+    wrapped_params[class_name.to_sym] = params
+
+    # For Ups and Fedex the endpoint is different
+    if params[:type] == 'UpsAccount' || params[:type] == 'FedexAccount'
+      create_url = "#{self.url}/register"
+    else
+      create_url = self.url
+    end
+
+    response = EasyPost.make_request(:post, create_url, api_key, wrapped_params)
+    EasyPost::Util.convert_to_easypost_object(response, api_key)
+  end
 end

--- a/lib/easypost/carrier_account.rb
+++ b/lib/easypost/carrier_account.rb
@@ -13,9 +13,9 @@ class EasyPost::CarrierAccount < EasyPost::Resource
 
     # For Ups and Fedex the endpoint is different
     if params[:type] == 'UpsAccount' || params[:type] == 'FedexAccount'
-      create_url = "#{self.url}/register"
+      create_url = "#{url}/register"
     else
-      create_url = self.url
+      create_url = url
     end
 
     response = EasyPost.make_request(:post, create_url, api_key, wrapped_params)

--- a/spec/carrier_account_spec.rb
+++ b/spec/carrier_account_spec.rb
@@ -18,11 +18,11 @@ describe EasyPost::CarrierAccount, :authenticate_prod do
     it 'sends FedexAccount to the correct endpoint' do
       allow(EasyPost).to receive(:make_request).with(
         :post, '/v2/carrier_accounts/register', nil, { carrier_account: { type: 'FedexAccount' } },
-      ).and_return({ 'id' => '123' })
+      ).and_return({ 'id' => 'ca_123' })
 
       response = described_class.create(type: 'FedexAccount')
 
-      expect(response).to be_an_instance_of(EasyPost::EasyPostObject)
+      expect(response).to be_an_instance_of(described_class)
     end
   end
 

--- a/spec/carrier_account_spec.rb
+++ b/spec/carrier_account_spec.rb
@@ -14,6 +14,16 @@ describe EasyPost::CarrierAccount, :authenticate_prod do
       # Remove the carrier account once we have tested it so we don't pollute the account with test accounts
       carrier_account.delete
     end
+
+    it 'sends FedexAccount to the correct endpoint' do
+      allow(EasyPost).to receive(:make_request).with(
+        :post, '/v2/carrier_accounts/register', nil, { carrier_account: { type: 'FedexAccount' } },
+      ).and_return({ 'id' => '123' })
+
+      response = described_class.create(type: 'FedexAccount')
+
+      expect(response).to be_an_instance_of(EasyPost::EasyPostObject)
+    end
   end
 
   describe '.retrieve' do


### PR DESCRIPTION
# Description

This fixes CarrierAccount creation endpoint for UpsAccount and FedexAccount that according to the docs https://support.easypost.com/hc/en-us/articles/360041148012-FedEx-Account-Registration-Guide and https://support.easypost.com/hc/en-us/articles/360024355712-Setting-up-your-UPS-Account should be sent to a different endpoint.

# Testing

Added tests

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
