### PR TITLE
fix: ignore directories for build

### DIFF
--- a/easypost.gemspec
+++ b/easypost.gemspec
@@ -7,7 +7,7 @@ require 'easypost/version'
 Gem::Specification.new do |spec|
   spec.name = 'easypost'
   spec.version = EasyPost::VERSION
-  spec.licenses = ['MIT']
+  spec.license = 'MIT'
   spec.summary = 'EasyPost Ruby Client Library'
   spec.description = 'Client library for accessing the EasyPost shipping API via Ruby.'
   spec.authors = 'EasyPost Developers'
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.homepage = 'https://www.easypost.com/docs'
 
   spec.files = `git ls-files -z`.split("\x0").reject do |f|
-    f.match(%r{^(test|spec|features)/})
+    f.match(%r{^(docs|examples|spec)/})
   end
   spec.executables = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']


### PR DESCRIPTION
# Description

Corrects the directories that get ignored when building. This command was initially copied from our friends at Twilio but never altered for our own needs some ~8 years ago heh. We didn't even have these directories ourselves.

<!-- Please provide a general summary of your PR changes and link any related issues or other pull requests. -->

# Testing

Inspected the gem contents with changes, looks appropriate for our needs.
<!-- 
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes 
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
