### PR TITLE
chore: drops Ruby 2.5, bumps deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rubyversion: ['2.5', '2.6', '2.7', '3.0', '3.1', '3.2']
+        rubyversion: ['2.6', '2.7', '3.0', '3.1', '3.2']
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,11 @@ inherit_from: easycop.yml
 
 AllCops:
   SuggestExtensions: false
+  Exclude:
+    - bin/**/*
+    - docs/**/*
+    - examples/**/*
+    - vendor/bundle/**/*
 # We are ignoring RSpec/FilePath because Simplecov doesn't play nice with nested spec files
 RSpec/FilePath:
   Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## Next Release (Major)
+
+- Drops support for Ruby 2.5
+- Bumps all dev dependencies
+
 ## v4.13.0 (2023-04-04)
 
 - Adds `get_next_page` function to each object which retrieves the next page of a collection when the `has_more` key is present in the response

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ docs:
 
 ## fix - Fix Rubocop errors
 fix:
-	bundle exec rubocop -A
+	bundle exec rubocop -a
 
 ## install - Install globally from source
 install:

--- a/easycop.yml
+++ b/easycop.yml
@@ -5,7 +5,7 @@
 require:
   - rubocop-rspec
 AllCops:
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.6
   NewCops: disable
 Layout/BlockAlignment:
   Enabled: true
@@ -41,7 +41,7 @@ Layout/FirstMethodArgumentLineBreak:
   Enabled: true
 Layout/LineLength:
   Max: 120
-  IgnoredPatterns: # deprecated in 1.28
+  AllowedPatterns:
     - "(\\A|\\s)#"
 Layout/LineEndStringConcatenationIndentation: # new in 1.18
   Enabled: true
@@ -104,7 +104,7 @@ Metrics/ParameterLists:
   Enabled: false
 Metrics/AbcSize:
   Enabled: false
-Gemspec/DateAssignment: # new in 1.10
+Gemspec/DeprecatedAttributeAssignment:
   Enabled: true
 Lint/AmbiguousAssignment: # new in 1.7
   Enabled: true

--- a/easypost.gemspec
+++ b/easypost.gemspec
@@ -19,18 +19,18 @@ Gem::Specification.new do |spec|
   end
   spec.executables = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.5'
+  spec.required_ruby_version = '>= 2.6'
 
-  spec.add_development_dependency 'brakeman', '~> 5.2'
+  spec.add_development_dependency 'brakeman', '~> 5.4'
   spec.add_development_dependency 'pry', '~> 0.14'
-  spec.add_development_dependency 'psych', '~> 4.0' # TODO: pinned because rdoc has an optimistic pin of this dep and 5.0 breaks on CI
+  spec.add_development_dependency 'psych', '~> 5.1'
   spec.add_development_dependency 'rake', '~> 13.0'
-  spec.add_development_dependency 'rdoc', '~> 6.4'
-  spec.add_development_dependency 'rspec', '~> 3.10'
-  spec.add_development_dependency 'rubocop', '= 1.27' # rubocop 1.28 requires Ruby 2.6+
-  spec.add_development_dependency 'rubocop-rspec', '= 2.10' # rubocop-rspec 2.11 requires Ruby 2.6+
-  spec.add_development_dependency 'simplecov', '~> 0.21'
+  spec.add_development_dependency 'rdoc', '~> 6.5'
+  spec.add_development_dependency 'rspec', '~> 3.12'
+  spec.add_development_dependency 'rubocop', '~> 1.49'
+  spec.add_development_dependency 'rubocop-rspec', '~> 2.19'
+  spec.add_development_dependency 'simplecov', '~> 0.22'
   spec.add_development_dependency 'simplecov-lcov', '~> 0.8'
-  spec.add_development_dependency 'vcr', '= 6.0' # VCR 6.1 requires Ruby 2.6+
-  spec.add_development_dependency 'webmock', '~> 3.14'
+  spec.add_development_dependency 'vcr', '~> 6.1'
+  spec.add_development_dependency 'webmock', '~> 3.18'
 end

--- a/lib/easypost/resource.rb
+++ b/lib/easypost/resource.rb
@@ -7,7 +7,7 @@ class EasyPost::Resource < EasyPost::EasyPostObject
   # The class name of an EasyPost object.
   def self.class_name
     camel = name.split('::')[-1]
-    snake = camel[0..0] + camel[1..-1].gsub(/([A-Z])/, '_\1')
+    snake = camel[0..0] + camel[1..].gsub(/([A-Z])/, '_\1')
     snake.downcase
   end
 
@@ -19,7 +19,7 @@ class EasyPost::Resource < EasyPost::EasyPostObject
       )
     end
 
-    if class_name[-1..-1] == 's' || class_name[-1..-1] == 'h'
+    if class_name[-1..] == 's' || class_name[-1..] == 'h'
       "/v2/#{CGI.escape(class_name.downcase)}es"
     else
       "/v2/#{CGI.escape(class_name.downcase)}s"

--- a/lib/easypost/util.rb
+++ b/lib/easypost/util.rb
@@ -116,7 +116,7 @@ module EasyPost::Util
   def self.build_dict_key(keys)
     result = keys[0].to_s
 
-    keys[1..-1].each do |key|
+    keys[1..].each do |key|
       result += "[#{key}]"
     end
 
@@ -187,7 +187,7 @@ module EasyPost::Util
     carriers_copy = carriers.clone
     carriers_copy.each do |carrier|
       if carrier[0, 1] == '!'
-        negative_carriers << carrier[1..-1]
+        negative_carriers << carrier[1..]
         carriers.delete(carrier)
       end
     end
@@ -197,7 +197,7 @@ module EasyPost::Util
     services_copy = services.clone
     services_copy.each do |service|
       if service[0, 1] == '!'
-        negative_services << service[1..-1]
+        negative_services << service[1..]
         services.delete(service)
       end
     end
@@ -239,7 +239,7 @@ module EasyPost::Util
     carriers_copy = carriers.clone
     carriers_copy.each do |carrier|
       if carrier[0, 1] == '!'
-        negative_carriers << carrier[1..-1]
+        negative_carriers << carrier[1..]
         carriers.delete(carrier)
       end
     end
@@ -249,7 +249,7 @@ module EasyPost::Util
     services_copy = services.clone
     services_copy.each do |service|
       if service[0, 1] == '!'
-        negative_services << service[1..-1]
+        negative_services << service[1..]
         services.delete(service)
       end
     end

--- a/spec/carrier_account_spec.rb
+++ b/spec/carrier_account_spec.rb
@@ -77,7 +77,7 @@ describe EasyPost::CarrierAccount, :authenticate_prod do
 
   describe '.types' do
     it 'retrieves the carrier account types available' do
-      types = described_class.types()
+      types = described_class.types
 
       expect(types).to be_an_instance_of(Array)
     end


### PR DESCRIPTION
# Description

- Drops support for Ruby 2.5
- Overhauls rubocop rules due to updates, fixes new errors, and ignores various top-level directories that rubocop was previously trying to lint that aren't ruby which results in much faster lint runs
- Bumps all deps

<!-- Please provide a general summary of your PR changes and link any related issues or other pull requests. -->

# Testing

<!-- 
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes 
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
