### PR TITLE
[feat] Support for custom connection for Ruby client

### DIFF
--- a/easypost.gemspec
+++ b/easypost.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.6'
 
   spec.add_development_dependency 'brakeman', '~> 5.4'
+  spec.add_development_dependency 'faraday', '~> 2.7.5' # used for integration tests
   spec.add_development_dependency 'pry', '~> 0.14'
   spec.add_development_dependency 'psych', '~> 5.1'
   spec.add_development_dependency 'rake', '~> 13.0'
@@ -31,6 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop-rspec', '2.19' # pin to 2.19 because latest version doesn't support Ruby 2.6
   spec.add_development_dependency 'simplecov', '~> 0.22'
   spec.add_development_dependency 'simplecov-lcov', '~> 0.8'
+  spec.add_development_dependency 'typhoeus', '~> 1.4.0' # used for integration tests
   spec.add_development_dependency 'vcr', '~> 6.1'
   spec.add_development_dependency 'webmock', '~> 3.18'
 end

--- a/lib/easypost/client.rb
+++ b/lib/easypost/client.rb
@@ -8,7 +8,15 @@ require 'json'
 class EasyPost::Client
   attr_reader :open_timeout, :read_timeout, :api_base
 
-  def initialize(api_key:, read_timeout: 60, open_timeout: 30, api_base: 'https://api.easypost.com')
+  # Initialize a new Client object
+  # @param api_key [String] the API key to be used for requests
+  # @param read_timeout [Integer] (60) the number of seconds to wait for a response before timing out
+  # @param open_timeout [Integer] (30) the number of seconds to wait for the connection to open before timing out
+  # @param api_base [String] ('https://api.easypost.com') the base URL for the API
+  # @param custom_client_exec [Proc] (nil) a custom client execution block to be used for requests instead of the default HTTP client (function signature: method, uri, headers, open_timeout, read_timeout, body = nil)
+  # @return [EasyPost::Client] the client object
+  def initialize(api_key:, read_timeout: 60, open_timeout: 30, api_base: 'https://api.easypost.com',
+                 custom_client_exec: nil)
     raise EasyPost::Errors::MissingParameterError.new('api_key') if api_key.nil?
 
     @api_key = api_key
@@ -20,7 +28,7 @@ class EasyPost::Client
 
     # Make an HTTP client once, reuse it for all requests made by this client
     # Configuration is immutable, so this is safe
-    @http_client = EasyPost::HttpClient.new(api_base, http_config)
+    @http_client = EasyPost::HttpClient.new(api_base, http_config, custom_client_exec)
   end
 
   SERVICE_CLASSES = [

--- a/lib/easypost/http_client.rb
+++ b/lib/easypost/http_client.rb
@@ -44,7 +44,7 @@ class EasyPost::HttpClient
       Net::HTTP.start(
         uri.host,
         uri.port, use_ssl: true, read_timeout: read_timeout, open_timeout: open_timeout,
-        ) do |http|
+      ) do |http|
         http.request(request)
       end
     rescue Net::ReadTimeout, Net::OpenTimeout, Errno::EHOSTUNREACH => e

--- a/lib/easypost/http_client.rb
+++ b/lib/easypost/http_client.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
 class EasyPost::HttpClient
-  def initialize(base_url, config)
+  def initialize(base_url, config, custom_client_exec = nil)
     @base_url = base_url
     @config = config
+    @custom_client_exec = custom_client_exec
   end
 
   # Execute an HTTP request to the API.
@@ -17,21 +18,32 @@ class EasyPost::HttpClient
     # Remove leading slash from path.
     path = path[1..] if path[0] == '/'
 
-    # Create the URI and headers hash.
     uri = URI.parse("#{@base_url}/#{api_version}/#{path}")
     headers = @config[:headers].merge(headers || {})
+    body = JSON.dump(EasyPost::InternalUtilities.objects_to_ids(body)) if body
+    open_timeout = @config[:open_timeout]
+    read_timeout = @config[:read_timeout]
 
+    # Execute the request, return the response.
+    if @custom_client_exec
+      @custom_client_exec.call(method, uri, headers, open_timeout, read_timeout, body)
+    else
+      default_request_execute(method, uri, headers, open_timeout, read_timeout, body)
+    end
+  end
+
+  def default_request_execute(method, uri, headers, open_timeout, read_timeout, body = nil)
     # Create the request, set the headers and body if necessary.
     request = Net::HTTP.const_get(method.capitalize).new(uri)
     headers.each { |k, v| request[k] = v }
-    request.body = JSON.dump(EasyPost::InternalUtilities.objects_to_ids(body)) if body
+    request.body = body if body
 
     begin
       # Attempt to make the request and return the response.
       Net::HTTP.start(
         uri.host,
-        uri.port, use_ssl: true, read_timeout: @config[:read_timeout], open_timeout: @config[:open_timeout],
-      ) do |http|
+        uri.port, use_ssl: true, read_timeout: read_timeout, open_timeout: open_timeout,
+        ) do |http|
         http.request(request)
       end
     rescue Net::ReadTimeout, Net::OpenTimeout, Errno::EHOSTUNREACH => e

--- a/lib/easypost/http_client.rb
+++ b/lib/easypost/http_client.rb
@@ -25,6 +25,7 @@ class EasyPost::HttpClient
     read_timeout = @config[:read_timeout]
 
     # Execute the request, return the response.
+
     if @custom_client_exec
       @custom_client_exec.call(method, uri, headers, open_timeout, read_timeout, body)
     else

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -40,5 +40,22 @@ describe EasyPost::Client do
         client.address.create(Fixture.ca_address1)
       }.to raise_error(EasyPost::Errors::TimeoutError)
     end
+
+    it 'calls custom client exec' do
+      client = described_class.new(
+        api_key: ENV['EASYPOST_TEST_API_KEY'],
+        custom_client_exec: lambda { |method, uri, headers, open_timeout, read_timeout, body = nil|
+          expect(method).to eq('get')
+          expect(uri).to be_a(URI)
+          expect(headers).to be_a(Hash)
+          expect(open_timeout).to eq(10)
+          expect(read_timeout).to eq(10)
+          expect(body).to be_nil
+        },
+      )
+
+      client.address.retrieve('adr_123')
+
+    end
   end
 end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -45,16 +45,19 @@ describe EasyPost::Client do
       client = described_class.new(
         api_key: ENV['EASYPOST_TEST_API_KEY'],
         custom_client_exec: lambda { |method, uri, headers, open_timeout, read_timeout, body = nil|
-          expect(method).to eq('get')
+          expect(method).to eq(:get)
           expect(uri).to be_a(URI)
           expect(headers).to be_a(Hash)
-          expect(open_timeout).to eq(10)
-          expect(read_timeout).to eq(10)
+          expect(open_timeout).to eq(30)
+          expect(read_timeout).to eq(60)
           expect(body).to be_nil
+          return OpenStruct.new(status_code: 401, body: '{}')
         },
       )
 
-      client.address.retrieve('adr_123')
+      expect {
+        client.address.retrieve('adr_123')
+      }.to raise_error(StandardError) # should throw error because our lambda returns 401
     end
   end
 end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'faraday'
+require 'typhoeus'
 
 describe EasyPost::Client do
   describe 'client object' do
@@ -43,7 +45,7 @@ describe EasyPost::Client do
 
     it 'calls custom client exec' do
       client = described_class.new(
-        api_key: ENV['EASYPOST_TEST_API_KEY'],
+        api_key: 'fake_api_key',
         custom_client_exec: lambda { |method, uri, headers, open_timeout, read_timeout, body = nil|
           expect(method).to eq(:get)
           expect(uri).to be_a(URI)
@@ -58,6 +60,60 @@ describe EasyPost::Client do
       expect {
         client.address.retrieve('adr_123')
       }.to raise_error(EasyPost::Errors::UnauthorizedError) # should throw error because our lambda returns 401
+    end
+
+    it 'allows Faraday to be used as a custom client' do
+      func = lambda { |method, uri, headers, _open_timeout, _read_timeout, body = nil|
+        conn = Faraday.new(url: uri.to_s, headers: headers) do |faraday|
+          faraday.adapter Faraday.default_adapter
+        end
+        conn.public_send(method, uri.path) { |request|
+          request.body = body if body
+        }.yield_self do |response|
+          # Verify that the request went through as expected
+          expect(response.env.method).to eq(method)
+          expect(response.env.url.to_s).to eq(uri.to_s)
+          # Normal users would use response.status and response.body, but for testing we'll explicitly return a 404
+          OpenStruct.new(code: 404, body: '{}')
+        end
+      }
+      client = described_class.new(
+        api_key: 'fake_api_key',
+        custom_client_exec: func,
+      )
+
+      expect {
+        client.address.retrieve('adr_123')
+      }.to raise_error(EasyPost::Errors::NotFoundError) # should throw error because our lambda returns 404
+    end
+
+    it 'allows Typhoeus to be used as a custom client' do
+      func = lambda { |method, uri, headers, _open_timeout, _read_timeout, body = nil|
+        Typhoeus.public_send(
+          method,
+          uri.to_s,
+          headers: headers,
+          body: body,
+        ).yield_self do |response|
+          # Verify that the request went through as expected
+          headers.each do |key, value|
+            expect(response.request.options[:headers][key]).to eq(value)
+          end
+          expect(response.request.options[:method]).to eq(method)
+          expect(response.request.options[:body]).to eq(body)
+          expect(response.request.base_url).to eq(uri.to_s)
+          # Normal users would use response.code and response.body, but for testing we'll explicitly return a 404
+          OpenStruct.new(code: 404, body: '{}')
+        end
+      }
+      client = described_class.new(
+        api_key: 'fake_api_key',
+        custom_client_exec: func,
+      )
+
+      expect {
+        client.address.retrieve('adr_123')
+      }.to raise_error(EasyPost::Errors::NotFoundError) # should throw error because our lambda returns 404
     end
   end
 end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -55,7 +55,6 @@ describe EasyPost::Client do
       )
 
       client.address.retrieve('adr_123')
-
     end
   end
 end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -51,13 +51,13 @@ describe EasyPost::Client do
           expect(open_timeout).to eq(30)
           expect(read_timeout).to eq(60)
           expect(body).to be_nil
-          return OpenStruct.new(status_code: 401, body: '{}')
+          return OpenStruct.new(code: 401, body: '{}')
         },
       )
 
       expect {
         client.address.retrieve('adr_123')
-      }.to raise_error(StandardError) # should throw error because our lambda returns 401
+      }.to raise_error(EasyPost::Errors::UnauthorizedError) # should throw error because our lambda returns 401
     end
   end
 end


### PR DESCRIPTION
# Description

Reintroduce #116 into thread-safe re-architecture for upcoming `v5`

Users define a `custom_client_exec` lambda function when initializing an `EasyPost::Client`. 

Function should respond to `call(method, uri, headers, open_timeout, read_timeout, body = nil)` where:
  - `uri` is the fully-qualified URL of the EasyPost endpoint, including query parameters
  - `method` is the lowercase name of the HTTP method being used for the request
  - `headers` is a hash with all headers needed for the request pre-populated, including authorization
  - `open_timeout` is an integer
  - `read_timeout` is an integer
  - `body` is a string of the body data to be included in the request, or nil (e.g. GET or DELETE request)
 
Function should return a response object with the following properties:
  - `code`: The integer status code for the response
  - `body`: The raw body data received in the response

# Testing

- Unit test confirms `custom_client_exec` is called and parameters are as expected
- Unit tests confirm Faraday and Typhoeus integration works as expected

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
