### PR TITLE
[chore] Fix formatting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,16 +61,18 @@ puts bought_shipment
 ### Custom Connections
 
 Pass in a lambda function as `custom_client_exec` when initializing a client that responds to `call(method, uri, headers, open_timeout, read_timeout, body = nil)` where:
-    - `uri` is the fully-qualified URL of the EasyPost endpoint, including query parameters (`Uri` object)
-    - `method` is the lowercase name of the HTTP method being used for the request (e.g. `:get`, `:post`, `:put`, `:delete`)
-    - `headers` is a hash with all headers needed for the request pre-populated, including authorization (`Hash` object)
-    - `open_timeout` is the number of seconds to wait for the connection to open (integer)
-    - `read_timeout` is the number of seconds to wait for one block to be read (integer)
-    - `body` is a string of the body data to be included in the request, or nil (e.g. GET or DELETE request) (string or `nil`)
+
+- `uri` is the fully-qualified URL of the EasyPost endpoint, including query parameters (`Uri` object)
+- `method` is the lowercase name of the HTTP method being used for the request (e.g. `:get`, `:post`, `:put`, `:delete`)
+- `headers` is a hash with all headers needed for the request pre-populated, including authorization (`Hash` object)
+- `open_timeout` is the number of seconds to wait for the connection to open (integer)
+- `read_timeout` is the number of seconds to wait for one block to be read (integer)
+- `body` is a string of the body data to be included in the request, or nil (e.g. GET or DELETE request) (string or `nil`)
 
 The lambda function should return an object with `code` and `body` attributes, where:
-    - `code` is the HTTP response status code (integer)
-    - `body` is the response body (string)
+
+- `code` is the HTTP response status code (integer)
+- `body` is the response body (string)
 
 #### Faraday
 


### PR DESCRIPTION
# Description

Custom Connections section formatting is improved. Best seen in formatted view: 
<img width="1022" alt="image" src="https://github.com/EasyPost/easypost-ruby/assets/17054780/0c8be0d8-f065-41fd-abbc-7b81591468b5">


# Testing

- N/A

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
