### PR TITLE
[fix] FedEx Smartpost hits register endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Next Release
+
+- Fix endpoint for creating a FedEx Smartpost carrier account
+
 ## v5.1.0 (2023-07-28)
 
 - Adds hooks to introspect the request and response of API calls (see `HTTP Hooks` section in the README for more details)

--- a/lib/easypost/services/carrier_account.rb
+++ b/lib/easypost/services/carrier_account.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class EasyPost::Services::CarrierAccount < EasyPost::Services::Service
-  CUSTOM_WORKFLOW_CARRIER_TYPES = %w[UpsAccount FedexAccount].freeze
+  CUSTOM_WORKFLOW_CARRIER_TYPES = %w[UpsAccount FedexAccount FedexSmartpostAccount].freeze
   MODEL_CLASS = EasyPost::Models::CarrierAccount
 
   # Create a carrier account


### PR DESCRIPTION
# Description

- FedEx SmartPost carrier account registration should hit `/register` endpoint for creation

# Testing

<!-- 
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes 
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
