### PR TITLE
[fix] Instance usage of get_payment_method_info in billing service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Next Release
+
+- Fix issues funding wallet due to invalid internal function call
+
 ## v6.1.0 (2024-01-08)
 
 - Add `all_children` and `get_next_page_of_children` in `user` service

--- a/lib/easypost/services/billing.rb
+++ b/lib/easypost/services/billing.rb
@@ -3,9 +3,48 @@
 require 'easypost/constants'
 
 class EasyPost::Services::Billing < EasyPost::Services::Service
+  # Fund your EasyPost wallet by charging your primary or secondary card on file.
+  def fund_wallet(amount, priority = 'primary')
+    payment_info = get_payment_method_info(priority.downcase)
+    endpoint = payment_info[0]
+    payment_id = payment_info[1]
+
+    wrapped_params = { amount: amount }
+    @client.make_request(:post, "#{endpoint}/#{payment_id}/charges", wrapped_params)
+
+    # Return true if succeeds, an error will be thrown if it fails
+    true
+  end
+
+  # Delete a payment method.
+  def delete_payment_method(priority)
+    payment_info = get_payment_method_info(priority.downcase)
+    endpoint = payment_info[0]
+    payment_id = payment_info[1]
+
+    @client.make_request(:delete, "#{endpoint}/#{payment_id}")
+
+    # Return true if succeeds, an error will be thrown if it fails
+    true
+  end
+
+  # Retrieve all payment methods.
+  def retrieve_payment_methods
+    response = @client.make_request(:get, '/payment_methods')
+    payment_methods = EasyPost::InternalUtilities::Json.convert_json_to_object(response)
+
+    if payment_methods['id'].nil?
+      raise EasyPost::Errors::InvalidObjectError.new(EasyPost::Constants::NO_PAYMENT_METHODS)
+    end
+
+    payment_methods
+  end
+
+  private
+
   # Get payment method info (type of the payment method and ID of the payment method)
-  def self.get_payment_method_info(priority)
-    payment_methods = EasyPost::Services::Billing.retrieve_payment_methods
+  def get_payment_method_info(priority)
+    payment_methods = retrieve_payment_methods
     payment_method_map = {
       'primary' => 'primary_payment_method',
       'secondary' => 'secondary_payment_method',
@@ -26,51 +65,14 @@ class EasyPost::Services::Billing < EasyPost::Services::Service
 
     unless payment_method_id.nil?
       if payment_method_id.start_with?('card_')
-        endpoint = '/v2/credit_cards'
+        endpoint = '/credit_cards'
       elsif payment_method_id.start_with?('bank_')
-        endpoint = '/v2/bank_accounts'
+        endpoint = '/bank_accounts'
       else
         raise EasyPost::Errors::InvalidObjectError.new(error_string)
       end
     end
 
     [endpoint, payment_method_id]
-  end
-
-  # Fund your EasyPost wallet by charging your primary or secondary card on file.
-  def fund_wallet(amount, priority = 'primary')
-    payment_info = EasyPost::Services::Billing.get_payment_method_info(priority.downcase)
-    endpoint = payment_info[0]
-    payment_id = payment_info[1]
-
-    wrapped_params = { amount: amount }
-    @client.make_request(:post, "#{endpoint}/#{payment_id}/charges", wrapped_params)
-
-    # Return true if succeeds, an error will be thrown if it fails
-    true
-  end
-
-  # Delete a payment method.
-  def delete_payment_method(priority)
-    payment_info = EasyPost::Services::Billing.get_payment_method_info(priority.downcase)
-    endpoint = payment_info[0]
-    payment_id = payment_info[1]
-
-    @client.make_request(:delete, "#{endpoint}/#{payment_id}")
-
-    # Return true if succeeds, an error will be thrown if it fails
-    true
-  end
-
-  # Retrieve all payment methods.
-  def retrieve_payment_methods
-    response = @client.make_request(:get, '/v2/payment_methods')
-    payment_methods = EasyPost::InternalUtilities::Json.convert_json_to_object(response)
-
-    if payment_methods['id'].nil?
-      raise EasyPost::Errors::InvalidObjectError.new(EasyPost::Constants::NO_PAYMENT_METHODS)
-    end
-
-    payment_methods
   end
 end

--- a/spec/billing_spec.rb
+++ b/spec/billing_spec.rb
@@ -7,11 +7,14 @@ describe EasyPost::Services::Billing do
 
   describe '.fund_wallet' do
     it 'fund wallet by using a payment method' do
-      allow(described_class).to receive(:get_payment_method_info).and_return(['/credit_cards', 'cc_123'])
-      allow(client).to receive(:make_request).with(
-        :post, '/credit_cards/cc_123/charges', { amount: '2000' },
-      )
-
+      allow(client).to receive(:make_request).with(:get, '/payment_methods')
+                                             .and_return({
+                                                           'id' => 'cust_thisisdummydata',
+                                                           'object' => 'PaymentMethods', 'primary_payment_method' =>
+                                                             { 'id' => 'card_123', 'object' => 'CreditCard' },
+                                                         },
+                                             )
+      allow(client).to receive(:make_request).with(:post, '/credit_cards/card_123/charges', { amount: '2000' })
       credit_card = client.billing.fund_wallet('2000', 'primary')
 
       expect(credit_card).to eq(true)
@@ -20,10 +23,14 @@ describe EasyPost::Services::Billing do
 
   describe '.delete_payment_method' do
     it 'delete a payment method' do
-      allow(described_class).to receive(:get_payment_method_info).and_return(['/credit_cards', 'cc_123'])
-      allow(client).to receive(:make_request).with(
-        :delete, '/credit_cards/cc_123',
-      )
+      allow(client).to receive(:make_request).with(:get, '/payment_methods')
+                                             .and_return({
+                                                           'id' => 'cust_thisisdummydata',
+                                                           'object' => 'PaymentMethods', 'primary_payment_method' =>
+                                                             { 'id' => 'card_123', 'object' => 'CreditCard' },
+                                                         },
+                                             )
+      allow(client).to receive(:make_request).with(:delete, '/credit_cards/card_123')
 
       deleted_credit_card = client.billing.delete_payment_method('primary')
 


### PR DESCRIPTION
# Description

As pointed out in #295 , a helper method in our billing service was static rather than instance-based, causing issues when calling it.

This PR makes the method a **private** instance helper method (not for end-user consumption), and updates the associated unit tests.

Closes #295 

# Testing

- Unit test updated, no cassettes need to be rerecorded (test was already mock-only)

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
