### PR TITLE
[bug] Cannot determine payment method when funding/deleting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next release
 
+- Fix payment method funding and deletion failures due to undetermined payment method type
 - Add `refund` function in Insurance service for requesting a refund for standalone insurance.
 
 ## v6.1.1 (2024-01-23)

--- a/lib/easypost/services/billing.rb
+++ b/lib/easypost/services/billing.rb
@@ -64,11 +64,11 @@ class EasyPost::Services::Billing < EasyPost::Services::Service
     payment_method_id = payment_methods[payment_method_to_use]['id']
     payment_method_object_type = payment_methods[payment_method_to_use]['object']
 
-    unless payment_method_id.nil?
-      if payment_method_id.start_with?('card_') || payment_method_object_type == 'CreditCard'
+    unless payment_method_object_type.nil?
+      if payment_method_object_type == 'CreditCard'
 
         endpoint = '/credit_cards'
-      elsif payment_method_id.start_with?('bank_') || payment_method_object_type == 'BankAccount'
+      elsif payment_method_object_type == 'BankAccount'
         endpoint = '/bank_accounts'
       else
         raise EasyPost::Errors::InvalidObjectError.new(error_string)

--- a/lib/easypost/services/billing.rb
+++ b/lib/easypost/services/billing.rb
@@ -62,11 +62,13 @@ class EasyPost::Services::Billing < EasyPost::Services::Service
     end
 
     payment_method_id = payment_methods[payment_method_to_use]['id']
+    payment_method_object_type = payment_methods[payment_method_to_use]['object']
 
     unless payment_method_id.nil?
-      if payment_method_id.start_with?('card_')
+      if payment_method_id.start_with?('card_') || payment_method_object_type == 'CreditCard'
+
         endpoint = '/credit_cards'
-      elsif payment_method_id.start_with?('bank_')
+      elsif payment_method_id.start_with?('bank_') || payment_method_object_type == 'BankAccount'
         endpoint = '/bank_accounts'
       else
         raise EasyPost::Errors::InvalidObjectError.new(error_string)

--- a/lib/easypost/services/billing.rb
+++ b/lib/easypost/services/billing.rb
@@ -64,15 +64,13 @@ class EasyPost::Services::Billing < EasyPost::Services::Service
     payment_method_id = payment_methods[payment_method_to_use]['id']
     payment_method_object_type = payment_methods[payment_method_to_use]['object']
 
-    unless payment_method_object_type.nil?
-      if payment_method_object_type == 'CreditCard'
+    if payment_method_object_type == 'CreditCard'
 
-        endpoint = '/credit_cards'
-      elsif payment_method_object_type == 'BankAccount'
-        endpoint = '/bank_accounts'
-      else
-        raise EasyPost::Errors::InvalidObjectError.new(error_string)
-      end
+      endpoint = '/credit_cards'
+    elsif payment_method_object_type == 'BankAccount'
+      endpoint = '/bank_accounts'
+    else
+      raise EasyPost::Errors::InvalidObjectError.new(error_string)
     end
 
     [endpoint, payment_method_id]

--- a/spec/billing_spec.rb
+++ b/spec/billing_spec.rb
@@ -11,7 +11,7 @@ describe EasyPost::Services::Billing do
                                              .and_return({
                                                            'id' => 'cust_thisisdummydata',
                                                            'object' => 'PaymentMethods', 'primary_payment_method' =>
-                                                             { 'id' => 'card_123', 'object' => 'CreditCard' },
+                                                             { 'id' => 'pm_123', 'object' => 'CreditCard' },
                                                          },
                                              )
       allow(client).to receive(:make_request).with(:post, '/credit_cards/card_123/charges', { amount: '2000' })
@@ -27,9 +27,53 @@ describe EasyPost::Services::Billing do
                                              .and_return({
                                                            'id' => 'cust_thisisdummydata',
                                                            'object' => 'PaymentMethods', 'primary_payment_method' =>
-                                                             { 'id' => 'card_123', 'object' => 'CreditCard' },
+                                                             { 'id' => 'pm_123', 'object' => 'CreditCard' },
                                                          },
                                              )
+      allow(client).to receive(:make_request).with(:delete, '/credit_cards/card_123')
+
+      deleted_credit_card = client.billing.delete_payment_method('primary')
+
+      expect(deleted_credit_card).to eq(true)
+    end
+  end
+
+  describe '.get_payment_method_info' do
+    it 'get payment method type by object type' do
+      allow(client).to receive(:make_request).with(:get, '/payment_methods')
+                                             .and_return({
+                                                           'id' => 'cust_thisisdummydata',
+                                                           'object' => 'PaymentMethods',
+                                                           'primary_payment_method' =>
+                                                             { 'id' => 'pm_123', 'object' => 'CreditCard' },
+                                                           'secondary_payment_method' =>
+                                                             { 'id' => 'pm_456', 'object' => 'BankAccount' },
+                                                         },
+                                                        )
+
+      # get_payment_method_info is private, can test it via delete
+      # will pass if get_payment_method_info returns ['credit_cards', 'pm_123'], fail otherwise
+      allow(client).to receive(:make_request).with(:delete, '/credit_cards/pm_123')
+
+      deleted_credit_card = client.billing.delete_payment_method('primary')
+
+      expect(deleted_credit_card).to eq(true)
+    end
+
+    it 'get payment method type by legacy ID prefix' do
+      allow(client).to receive(:make_request).with(:get, '/payment_methods')
+                                             .and_return({
+                                                           'id' => 'cust_thisisdummydata',
+                                                           'object' => 'PaymentMethods',
+                                                           'primary_payment_method' =>
+                                                             { 'id' => 'card_123', 'object' => nil },
+                                                           'secondary_payment_method' =>
+                                                             { 'id' => 'bank_456', 'object' => nil },
+                                                         },
+                                                        )
+
+      # get_payment_method_info is private, can test it via delete
+      # will pass if get_payment_method_info returns ['credit_cards', 'card_123'], fail otherwise
       allow(client).to receive(:make_request).with(:delete, '/credit_cards/card_123')
 
       deleted_credit_card = client.billing.delete_payment_method('primary')

--- a/spec/billing_spec.rb
+++ b/spec/billing_spec.rb
@@ -59,26 +59,5 @@ describe EasyPost::Services::Billing do
 
       expect(deleted_credit_card).to eq(true)
     end
-
-    it 'get payment method type by legacy ID prefix' do
-      allow(client).to receive(:make_request).with(:get, '/payment_methods')
-                                             .and_return({
-                                                           'id' => 'cust_thisisdummydata',
-                                                           'object' => 'PaymentMethods',
-                                                           'primary_payment_method' =>
-                                                             { 'id' => 'card_123', 'object' => nil },
-                                                           'secondary_payment_method' =>
-                                                             { 'id' => 'bank_456', 'object' => nil },
-                                                         },
-                                                        )
-
-      # get_payment_method_info is private, can test it via delete
-      # will pass if get_payment_method_info returns ['credit_cards', 'card_123'], fail otherwise
-      allow(client).to receive(:make_request).with(:delete, '/credit_cards/card_123')
-
-      deleted_credit_card = client.billing.delete_payment_method('primary')
-
-      expect(deleted_credit_card).to eq(true)
-    end
   end
 end

--- a/spec/billing_spec.rb
+++ b/spec/billing_spec.rb
@@ -14,7 +14,7 @@ describe EasyPost::Services::Billing do
                                                              { 'id' => 'pm_123', 'object' => 'CreditCard' },
                                                          },
                                              )
-      allow(client).to receive(:make_request).with(:post, '/credit_cards/card_123/charges', { amount: '2000' })
+      allow(client).to receive(:make_request).with(:post, '/credit_cards/pm_123/charges', { amount: '2000' })
       credit_card = client.billing.fund_wallet('2000', 'primary')
 
       expect(credit_card).to eq(true)
@@ -30,7 +30,7 @@ describe EasyPost::Services::Billing do
                                                              { 'id' => 'pm_123', 'object' => 'CreditCard' },
                                                          },
                                              )
-      allow(client).to receive(:make_request).with(:delete, '/credit_cards/card_123')
+      allow(client).to receive(:make_request).with(:delete, '/credit_cards/pm_123')
 
       deleted_credit_card = client.billing.delete_payment_method('primary')
 


### PR DESCRIPTION
# Description

- Use payment method object type as fallback when determining type for fund, delete functions

# Testing

- Update, add unit test to confirm legacy (by ID prefix) and new (by object type) both work to determine payment method type

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
