### PR TITLE
fix: rdoc generation excluding MODEL_CLASS (closes #317)

### DIFF
--- a/easypost.gemspec
+++ b/easypost.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'faraday', '~> 2.7.5' # used for integration tests
   spec.add_development_dependency 'pry', '~> 0.14'
   spec.add_development_dependency 'rake', '~> 13.0'
-  spec.add_development_dependency 'rdoc', '~> 6.5'
+  spec.add_development_dependency 'rdoc', '~> 6.9'
   spec.add_development_dependency 'rspec', '~> 3.12'
   spec.add_development_dependency 'rubocop', '~> 1.49'
   spec.add_development_dependency 'rubocop-rspec', '2.19' # pin to 2.19 because latest version doesn't support Ruby 2.6

--- a/lib/easypost/services/address.rb
+++ b/lib/easypost/services/address.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class EasyPost::Services::Address < EasyPost::Services::Service
-  MODEL_CLASS = EasyPost::Models::Address
+  MODEL_CLASS = EasyPost::Models::Address #:nodoc:
 
   # Create an address.
   def create(params = {})

--- a/lib/easypost/services/address.rb
+++ b/lib/easypost/services/address.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class EasyPost::Services::Address < EasyPost::Services::Service
-  MODEL_CLASS = EasyPost::Models::Address #:nodoc:
+  MODEL_CLASS = EasyPost::Models::Address # :nodoc:
 
   # Create an address.
   def create(params = {})

--- a/lib/easypost/services/batch.rb
+++ b/lib/easypost/services/batch.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class EasyPost::Services::Batch < EasyPost::Services::Service
-  MODEL_CLASS = EasyPost::Models::Batch
+  MODEL_CLASS = EasyPost::Models::Batch #:nodoc:
 
   # Create a Batch.
   def create(params = {})

--- a/lib/easypost/services/batch.rb
+++ b/lib/easypost/services/batch.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class EasyPost::Services::Batch < EasyPost::Services::Service
-  MODEL_CLASS = EasyPost::Models::Batch #:nodoc:
+  MODEL_CLASS = EasyPost::Models::Batch # :nodoc:
 
   # Create a Batch.
   def create(params = {})

--- a/lib/easypost/services/carrier_account.rb
+++ b/lib/easypost/services/carrier_account.rb
@@ -3,7 +3,7 @@
 class EasyPost::Services::CarrierAccount < EasyPost::Services::Service
   CUSTOM_WORKFLOW_CARRIER_TYPES = %w[FedexAccount FedexSmartpostAccount].freeze
   UPS_OAUTH_CARRIER_ACCOUNT_TYPES = %w[UpsAccount UpsMailInnovationsAccount UpsSurepostAccount].freeze
-  MODEL_CLASS = EasyPost::Models::CarrierAccount #:nodoc:
+  MODEL_CLASS = EasyPost::Models::CarrierAccount # :nodoc:
 
   # Create a carrier account
   def create(params = {})

--- a/lib/easypost/services/carrier_account.rb
+++ b/lib/easypost/services/carrier_account.rb
@@ -3,7 +3,7 @@
 class EasyPost::Services::CarrierAccount < EasyPost::Services::Service
   CUSTOM_WORKFLOW_CARRIER_TYPES = %w[FedexAccount FedexSmartpostAccount].freeze
   UPS_OAUTH_CARRIER_ACCOUNT_TYPES = %w[UpsAccount UpsMailInnovationsAccount UpsSurepostAccount].freeze
-  MODEL_CLASS = EasyPost::Models::CarrierAccount
+  MODEL_CLASS = EasyPost::Models::CarrierAccount #:nodoc:
 
   # Create a carrier account
   def create(params = {})

--- a/lib/easypost/services/carrier_type.rb
+++ b/lib/easypost/services/carrier_type.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class EasyPost::Services::CarrierType < EasyPost::Services::Service
-  MODEL_CLASS = EasyPost::Models::CarrierType #:nodoc:
+  MODEL_CLASS = EasyPost::Models::CarrierType # :nodoc:
 
   # Retrieve all carrier types
   def all

--- a/lib/easypost/services/carrier_type.rb
+++ b/lib/easypost/services/carrier_type.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class EasyPost::Services::CarrierType < EasyPost::Services::Service
-  MODEL_CLASS = EasyPost::Models::CarrierType
+  MODEL_CLASS = EasyPost::Models::CarrierType #:nodoc:
 
   # Retrieve all carrier types
   def all

--- a/lib/easypost/services/claim.rb
+++ b/lib/easypost/services/claim.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class EasyPost::Services::Claim < EasyPost::Services::Service
-  MODEL_CLASS = EasyPost::Models::Claim
+  MODEL_CLASS = EasyPost::Models::Claim #:nodoc:
 
   # Create an Claim object
   def create(params = {})

--- a/lib/easypost/services/claim.rb
+++ b/lib/easypost/services/claim.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class EasyPost::Services::Claim < EasyPost::Services::Service
-  MODEL_CLASS = EasyPost::Models::Claim #:nodoc:
+  MODEL_CLASS = EasyPost::Models::Claim # :nodoc:
 
   # Create an Claim object
   def create(params = {})

--- a/lib/easypost/services/customs_info.rb
+++ b/lib/easypost/services/customs_info.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class EasyPost::Services::CustomsInfo < EasyPost::Services::Service
-  MODEL_CLASS = EasyPost::Models::CustomsInfo #:nodoc:
+  MODEL_CLASS = EasyPost::Models::CustomsInfo # :nodoc:
 
   # Create a CustomsInfo object
   def create(params)

--- a/lib/easypost/services/customs_info.rb
+++ b/lib/easypost/services/customs_info.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class EasyPost::Services::CustomsInfo < EasyPost::Services::Service
-  MODEL_CLASS = EasyPost::Models::CustomsInfo
+  MODEL_CLASS = EasyPost::Models::CustomsInfo #:nodoc:
 
   # Create a CustomsInfo object
   def create(params)

--- a/lib/easypost/services/customs_item.rb
+++ b/lib/easypost/services/customs_item.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class EasyPost::Services::CustomsItem < EasyPost::Services::Service
-  MODEL_CLASS = EasyPost::Models::CustomsItem #:nodoc:
+  MODEL_CLASS = EasyPost::Models::CustomsItem # :nodoc:
 
   # Create a CustomsItem object
   def create(params)

--- a/lib/easypost/services/customs_item.rb
+++ b/lib/easypost/services/customs_item.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class EasyPost::Services::CustomsItem < EasyPost::Services::Service
-  MODEL_CLASS = EasyPost::Models::CustomsItem
+  MODEL_CLASS = EasyPost::Models::CustomsItem #:nodoc:
 
   # Create a CustomsItem object
   def create(params)

--- a/lib/easypost/services/end_shipper.rb
+++ b/lib/easypost/services/end_shipper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class EasyPost::Services::EndShipper < EasyPost::Services::Service
-  MODEL_CLASS = EasyPost::Models::EndShipper #:nodoc:
+  MODEL_CLASS = EasyPost::Models::EndShipper # :nodoc:
 
   # Create an EndShipper object.
   def create(params = {})

--- a/lib/easypost/services/end_shipper.rb
+++ b/lib/easypost/services/end_shipper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class EasyPost::Services::EndShipper < EasyPost::Services::Service
-  MODEL_CLASS = EasyPost::Models::EndShipper
+  MODEL_CLASS = EasyPost::Models::EndShipper #:nodoc:
 
   # Create an EndShipper object.
   def create(params = {})

--- a/lib/easypost/services/event.rb
+++ b/lib/easypost/services/event.rb
@@ -3,7 +3,7 @@
 require 'json'
 
 class EasyPost::Services::Event < EasyPost::Services::Service
-  MODEL_CLASS = EasyPost::Models::Event #:nodoc:
+  MODEL_CLASS = EasyPost::Models::Event # :nodoc:
 
   # Retrieve an Event object
   def retrieve(id)

--- a/lib/easypost/services/event.rb
+++ b/lib/easypost/services/event.rb
@@ -3,7 +3,7 @@
 require 'json'
 
 class EasyPost::Services::Event < EasyPost::Services::Service
-  MODEL_CLASS = EasyPost::Models::Event
+  MODEL_CLASS = EasyPost::Models::Event #:nodoc:
 
   # Retrieve an Event object
   def retrieve(id)

--- a/lib/easypost/services/insurance.rb
+++ b/lib/easypost/services/insurance.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class EasyPost::Services::Insurance < EasyPost::Services::Service
-  MODEL_CLASS = EasyPost::Models::Insurance #:nodoc:
+  MODEL_CLASS = EasyPost::Models::Insurance # :nodoc:
 
   # Create an Insurance object
   def create(params = {})

--- a/lib/easypost/services/insurance.rb
+++ b/lib/easypost/services/insurance.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class EasyPost::Services::Insurance < EasyPost::Services::Service
-  MODEL_CLASS = EasyPost::Models::Insurance
+  MODEL_CLASS = EasyPost::Models::Insurance #:nodoc:
 
   # Create an Insurance object
   def create(params = {})

--- a/lib/easypost/services/order.rb
+++ b/lib/easypost/services/order.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class EasyPost::Services::Order < EasyPost::Services::Service
-  MODEL_CLASS = EasyPost::Models::Order
+  MODEL_CLASS = EasyPost::Models::Order #:nodoc:
 
   # Create an Order object
   def create(params = {})

--- a/lib/easypost/services/order.rb
+++ b/lib/easypost/services/order.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class EasyPost::Services::Order < EasyPost::Services::Service
-  MODEL_CLASS = EasyPost::Models::Order #:nodoc:
+  MODEL_CLASS = EasyPost::Models::Order # :nodoc:
 
   # Create an Order object
   def create(params = {})

--- a/lib/easypost/services/parcel.rb
+++ b/lib/easypost/services/parcel.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class EasyPost::Services::Parcel < EasyPost::Services::Service
-  MODEL_CLASS = EasyPost::Models::Parcel #:nodoc:
+  MODEL_CLASS = EasyPost::Models::Parcel # :nodoc:
 
   # Create a Parcel object
   def create(params = {})

--- a/lib/easypost/services/parcel.rb
+++ b/lib/easypost/services/parcel.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class EasyPost::Services::Parcel < EasyPost::Services::Service
-  MODEL_CLASS = EasyPost::Models::Parcel
+  MODEL_CLASS = EasyPost::Models::Parcel #:nodoc:
 
   # Create a Parcel object
   def create(params = {})

--- a/lib/easypost/services/pickup.rb
+++ b/lib/easypost/services/pickup.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class EasyPost::Services::Pickup < EasyPost::Services::Service
-  MODEL_CLASS = EasyPost::Models::Pickup
+  MODEL_CLASS = EasyPost::Models::Pickup #:nodoc:
 
   # Create a Pickup object
   def create(params = {})

--- a/lib/easypost/services/pickup.rb
+++ b/lib/easypost/services/pickup.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class EasyPost::Services::Pickup < EasyPost::Services::Service
-  MODEL_CLASS = EasyPost::Models::Pickup #:nodoc:
+  MODEL_CLASS = EasyPost::Models::Pickup # :nodoc:
 
   # Create a Pickup object
   def create(params = {})

--- a/lib/easypost/services/referral_customer.rb
+++ b/lib/easypost/services/referral_customer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class EasyPost::Services::ReferralCustomer < EasyPost::Services::Service
-  MODEL_CLASS = EasyPost::Models::User
+  MODEL_CLASS = EasyPost::Models::User #:nodoc:
 
   # Create a referral customer. This function requires the Partner User's API key.
   def create(params = {})

--- a/lib/easypost/services/referral_customer.rb
+++ b/lib/easypost/services/referral_customer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class EasyPost::Services::ReferralCustomer < EasyPost::Services::Service
-  MODEL_CLASS = EasyPost::Models::User #:nodoc:
+  MODEL_CLASS = EasyPost::Models::User # :nodoc:
 
   # Create a referral customer. This function requires the Partner User's API key.
   def create(params = {})

--- a/lib/easypost/services/refund.rb
+++ b/lib/easypost/services/refund.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class EasyPost::Services::Refund < EasyPost::Services::Service
-  MODEL_CLASS = EasyPost::Models::Refund #:nodoc:
+  MODEL_CLASS = EasyPost::Models::Refund # :nodoc:
 
   # Create a Refund object
   def create(params = {})

--- a/lib/easypost/services/refund.rb
+++ b/lib/easypost/services/refund.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class EasyPost::Services::Refund < EasyPost::Services::Service
-  MODEL_CLASS = EasyPost::Models::Refund
+  MODEL_CLASS = EasyPost::Models::Refund #:nodoc:
 
   # Create a Refund object
   def create(params = {})

--- a/lib/easypost/services/report.rb
+++ b/lib/easypost/services/report.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class EasyPost::Services::Report < EasyPost::Services::Service
-  MODEL_CLASS = EasyPost::Models::Report #:nodoc:
+  MODEL_CLASS = EasyPost::Models::Report # :nodoc:
 
   # Create a Report
   def create(params = {})

--- a/lib/easypost/services/report.rb
+++ b/lib/easypost/services/report.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class EasyPost::Services::Report < EasyPost::Services::Service
-  MODEL_CLASS = EasyPost::Models::Report
+  MODEL_CLASS = EasyPost::Models::Report #:nodoc:
 
   # Create a Report
   def create(params = {})

--- a/lib/easypost/services/scan_form.rb
+++ b/lib/easypost/services/scan_form.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class EasyPost::Services::ScanForm < EasyPost::Services::Service
-  MODEL_CLASS = EasyPost::Models::ScanForm
+  MODEL_CLASS = EasyPost::Models::ScanForm #:nodoc:
 
   # Create a ScanForm.
   def create(params = {})

--- a/lib/easypost/services/scan_form.rb
+++ b/lib/easypost/services/scan_form.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class EasyPost::Services::ScanForm < EasyPost::Services::Service
-  MODEL_CLASS = EasyPost::Models::ScanForm #:nodoc:
+  MODEL_CLASS = EasyPost::Models::ScanForm # :nodoc:
 
   # Create a ScanForm.
   def create(params = {})

--- a/lib/easypost/services/shipment.rb
+++ b/lib/easypost/services/shipment.rb
@@ -3,7 +3,7 @@
 require 'set'
 
 class EasyPost::Services::Shipment < EasyPost::Services::Service
-  MODEL_CLASS = EasyPost::Models::Shipment #:nodoc:
+  MODEL_CLASS = EasyPost::Models::Shipment # :nodoc:
 
   # Create a Shipment.
   def create(params = {})

--- a/lib/easypost/services/shipment.rb
+++ b/lib/easypost/services/shipment.rb
@@ -3,7 +3,7 @@
 require 'set'
 
 class EasyPost::Services::Shipment < EasyPost::Services::Service
-  MODEL_CLASS = EasyPost::Models::Shipment
+  MODEL_CLASS = EasyPost::Models::Shipment #:nodoc:
 
   # Create a Shipment.
   def create(params = {})

--- a/lib/easypost/services/tracker.rb
+++ b/lib/easypost/services/tracker.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class EasyPost::Services::Tracker < EasyPost::Services::Service
-  MODEL_CLASS = EasyPost::Models::Tracker #:nodoc:
+  MODEL_CLASS = EasyPost::Models::Tracker # :nodoc:
 
   # Create a Tracker
   def create(params = {})

--- a/lib/easypost/services/tracker.rb
+++ b/lib/easypost/services/tracker.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class EasyPost::Services::Tracker < EasyPost::Services::Service
-  MODEL_CLASS = EasyPost::Models::Tracker
+  MODEL_CLASS = EasyPost::Models::Tracker #:nodoc:
 
   # Create a Tracker
   def create(params = {})

--- a/lib/easypost/services/user.rb
+++ b/lib/easypost/services/user.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class EasyPost::Services::User < EasyPost::Services::Service
-  MODEL_CLASS = EasyPost::Models::User
+  MODEL_CLASS = EasyPost::Models::User #:nodoc:
 
   # Create a child User.
   def create(params = {})

--- a/lib/easypost/services/user.rb
+++ b/lib/easypost/services/user.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class EasyPost::Services::User < EasyPost::Services::Service
-  MODEL_CLASS = EasyPost::Models::User #:nodoc:
+  MODEL_CLASS = EasyPost::Models::User # :nodoc:
 
   # Create a child User.
   def create(params = {})

--- a/lib/easypost/services/webhook.rb
+++ b/lib/easypost/services/webhook.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class EasyPost::Services::Webhook < EasyPost::Services::Service
-  MODEL_CLASS = EasyPost::Models::Webhook #:nodoc:
+  MODEL_CLASS = EasyPost::Models::Webhook # :nodoc:
 
   # Create a Webhook.
   def create(params = {})

--- a/lib/easypost/services/webhook.rb
+++ b/lib/easypost/services/webhook.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class EasyPost::Services::Webhook < EasyPost::Services::Service
-  MODEL_CLASS = EasyPost::Models::Webhook
+  MODEL_CLASS = EasyPost::Models::Webhook #:nodoc:
 
   # Create a Webhook.
   def create(params = {})


### PR DESCRIPTION
# Description

Rdoc was getting confused about the constant taking precedence over the class name for classes containing a `MODEL_CLASS`, this change tells rdoc not to document the constant which wasn't needed to begin with which removes the unnecessary `MODEL_CLASS` doc generation and cleans up the resulting output.

Also bumps rdoc to use newer stylized docs output.

Closes #317 

<!-- Please provide a general summary of your PR changes and link any related issues or other pull requests. -->

# Testing

See new output: 

![Screenshot 2024-12-17 at 11 13 08 AM](https://github.com/user-attachments/assets/f9ada6cf-a2c6-4b2a-9184-78fe35687829)

<!-- 
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes 
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
